### PR TITLE
remove log4j from report-generator

### DIFF
--- a/report-generator/build.gradle
+++ b/report-generator/build.gradle
@@ -12,9 +12,6 @@ dependencies {
 	implementation "org.jacoco:org.jacoco.report:$jacocoVersion"
 	implementation "org.jacoco:org.jacoco.agent:$jacocoVersion:runtime"
 
-	implementation "org.apache.logging.log4j:log4j-api:$log4jVersion"
-	implementation "org.apache.logging.log4j:log4j-core:$log4jVersion"
-
 	implementation 'com.squareup.moshi:moshi:1.8.0'
 
 	testImplementation 'org.junit.jupiter:junit-jupiter-api:5.4.2'


### PR DESCRIPTION
not needed (we use ILogger everywhere) and causes problems for the agent

Addresses issue #80

- [x] [No new Teamscale findings](https://build.cqse.eu/teamscale/delta.html#input/jacoco-client/?showMergeFindings=true)
- [x] [Changes are tested adequately](https://build.cqse.eu/teamscale/tests.html#/jacoco-client/)
- [x] Agent's README.md updated in case of user-visible changes (not needed)
- [x] CHANGELOG.md updated (not needed)

