### PR TITLE
fix NPE when reading manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 We use [semantic versioning][semver]
 
 # Next version
+- [fix] prevent NPE when trying to read manifest from Jar file
 
 # 15.1.0
 - [feature] supplying a `class-dir` option is no longer mandatory

--- a/agent/src/main/java/com/teamscale/jacoco/agent/AgentOptionsParser.java
+++ b/agent/src/main/java/com/teamscale/jacoco/agent/AgentOptionsParser.java
@@ -290,6 +290,10 @@ public class AgentOptionsParser {
 	private CommitDescriptor getCommitFromManifest(File jarFile) throws AgentOptionParseException {
 		try (JarInputStream jarStream = new JarInputStream(new FileInputStream(jarFile))) {
 			Manifest manifest = jarStream.getManifest();
+			if (manifest == null) {
+				throw new AgentOptionParseException(
+						"Unable to read manifest from " + jarFile + ". Maybe the manifest is corrupt?");
+			}
 			String branch = manifest.getMainAttributes().getValue("Branch");
 			String timestamp = manifest.getMainAttributes().getValue("Timestamp");
 			if (StringUtils.isEmpty(branch)) {


### PR DESCRIPTION
Addresses issue #59 

- [ ] [Changes are tested adequately](https://build.cqse.eu/teamscale/tests.html#/jacoco-client/) - not tested, one line fix
- [ ] Agent's README.md updated in case of user-visible changes - not needed
- [x] CHANGELOG.md updated

Please respect the vote of the [Teamscale bot](https://demo.teamscale.com) or flag irrelevant findings as tolerated or false positives. If you feel that the Teamscale config needs adjustment, please state so in a comment and discuss this with your reviewer.

