### PR TITLE
Reuse ereportformat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ We use [semantic versioning][semver]
 
 # Next Release
 - [documentation] Configuration for SAP NetWeaver Java (>= 7.50) is now documented
+- [feature] teamscale-client accepts `String` as report format as well
+- [feature] teamscale-client allows attaching arbitrary `Interceptor`s to Teamscale service
 
 # 15.1.0
 - [feature] supplying a `class-dir` option is no longer mandatory

--- a/agent/src/main/java/com/teamscale/jacoco/agent/AgentBase.java
+++ b/agent/src/main/java/com/teamscale/jacoco/agent/AgentBase.java
@@ -1,7 +1,7 @@
 package com.teamscale.jacoco.agent;
 
 import com.teamscale.jacoco.agent.util.LoggingUtils;
-import eu.cqse.teamscale.client.HttpUtils;
+import com.teamscale.client.HttpUtils;
 import org.jacoco.agent.rt.RT;
 import org.slf4j.Logger;
 

--- a/agent/src/main/java/com/teamscale/jacoco/agent/store/upload/UploadStoreBase.java
+++ b/agent/src/main/java/com/teamscale/jacoco/agent/store/upload/UploadStoreBase.java
@@ -5,7 +5,7 @@ import com.teamscale.jacoco.agent.store.UploadStoreException;
 import com.teamscale.jacoco.agent.store.file.TimestampedFileStore;
 import com.teamscale.jacoco.agent.util.Benchmark;
 import com.teamscale.jacoco.agent.util.LoggingUtils;
-import eu.cqse.teamscale.client.HttpUtils;
+import com.teamscale.client.HttpUtils;
 import okhttp3.HttpUrl;
 import okhttp3.ResponseBody;
 import org.conqat.lib.commons.filesystem.FileSystemUtils;

--- a/teamscale-client/src/main/java/com/teamscale/client/HttpUtils.java
+++ b/teamscale-client/src/main/java/com/teamscale/client/HttpUtils.java
@@ -1,4 +1,4 @@
-package eu.cqse.teamscale.client;
+package com.teamscale.client;
 
 import okhttp3.OkHttpClient;
 import org.slf4j.Logger;

--- a/teamscale-client/src/main/java/com/teamscale/client/ITeamscaleService.java
+++ b/teamscale-client/src/main/java/com/teamscale/client/ITeamscaleService.java
@@ -34,6 +34,7 @@ public interface ITeamscaleService {
 			@Part("report") RequestBody report
 	);
 
+	/** Report upload API with {@link EReportFormat}. */
 	default Call<ResponseBody> uploadExternalReport(
 			String projectName,
 			EReportFormat format,

--- a/teamscale-client/src/main/java/com/teamscale/client/ITeamscaleService.java
+++ b/teamscale-client/src/main/java/com/teamscale/client/ITeamscaleService.java
@@ -25,7 +25,7 @@ public interface ITeamscaleService {
 	@POST("p/{projectName}/external-report/")
 	Call<ResponseBody> uploadExternalReport(
 			@Path("projectName") String projectName,
-			@Query("format") EReportFormat format,
+			@Query("format") String format,
 			@Query("t") CommitDescriptor commit,
 			@Query("adjusttimestamp") boolean adjustTimestamp,
 			@Query("movetolastcommit") boolean moveToLastCommit,
@@ -33,6 +33,20 @@ public interface ITeamscaleService {
 			@Query("message") String message,
 			@Part("report") RequestBody report
 	);
+
+	default Call<ResponseBody> uploadExternalReport(
+			String projectName,
+			EReportFormat format,
+			CommitDescriptor commit,
+			boolean adjustTimestamp,
+			boolean moveToLastCommit,
+			String partition,
+			String message,
+			RequestBody report
+	) {
+		return uploadExternalReport(projectName, format.name(), commit, adjustTimestamp, moveToLastCommit, partition,
+				message, report);
+	}
 
 	/** Report upload API for multiple reports at once. */
 	@Multipart
@@ -68,8 +82,8 @@ public interface ITeamscaleService {
 	);
 
 	/**
-	 * Uploads the given report body to Teamscale as blocking call
-	 * with adjusttimestamp and movetolastcommit set to true.
+	 * Uploads the given report body to Teamscale as blocking call with adjusttimestamp and movetolastcommit set to
+	 * true.
 	 *
 	 * @return Returns the request body if successful, otherwise throws an IOException.
 	 */

--- a/teamscale-client/src/main/java/com/teamscale/client/TeamscaleServiceGenerator.java
+++ b/teamscale-client/src/main/java/com/teamscale/client/TeamscaleServiceGenerator.java
@@ -1,8 +1,8 @@
 package com.teamscale.client;
 
-import com.teamscale.client.HttpUtils;
 import okhttp3.HttpUrl;
 import okhttp3.Interceptor;
+import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
 import retrofit2.Retrofit;
@@ -19,21 +19,29 @@ public class TeamscaleServiceGenerator {
 	 * Generates a {@link Retrofit} instance for the given service, which uses basic auth to authenticate against the
 	 * server and which sets the accept header to json.
 	 */
-	public static <S> S createService(Class<S> serviceClass, HttpUrl baseUrl, String username, String accessToken) {
+	public static <S> S createService(Class<S> serviceClass, HttpUrl baseUrl, String username, String accessToken,
+									  Interceptor... interceptors) {
 		Retrofit retrofit = HttpUtils.createRetrofit(
 				retrofitBuilder -> retrofitBuilder.baseUrl(baseUrl).addConverterFactory(MoshiConverterFactory.create()),
-				okHttpBuilder -> okHttpBuilder
+				okHttpBuilder -> addInterceptors(okHttpBuilder, interceptors)
 						.addInterceptor(TeamscaleServiceGenerator.getBasicAuthInterceptor(username, accessToken))
 						.addInterceptor(new AcceptJsonInterceptor())
 		);
 		return retrofit.create(serviceClass);
 	}
 
+	private static OkHttpClient.Builder addInterceptors(OkHttpClient.Builder builder, Interceptor... interceptors) {
+		for (Interceptor interceptor : interceptors) {
+			builder.addInterceptor(interceptor);
+		}
+		return builder;
+	}
+
 	public static <S> S createServiceWithRequestLogging(Class<S> serviceClass, HttpUrl baseUrl, String username,
-														String accessToken, File file) {
+														String accessToken, File file, Interceptor... interceptors) {
 		Retrofit retrofit = HttpUtils.createRetrofit(
 				retrofitBuilder -> retrofitBuilder.baseUrl(baseUrl).addConverterFactory(MoshiConverterFactory.create()),
-				okHttpBuilder -> okHttpBuilder
+				okHttpBuilder -> addInterceptors(okHttpBuilder, interceptors)
 						.addInterceptor(TeamscaleServiceGenerator.getBasicAuthInterceptor(username, accessToken))
 						.addInterceptor(new AcceptJsonInterceptor())
 						.addInterceptor(new FileLoggingInterceptor(file))

--- a/teamscale-client/src/main/java/com/teamscale/client/TeamscaleServiceGenerator.java
+++ b/teamscale-client/src/main/java/com/teamscale/client/TeamscaleServiceGenerator.java
@@ -1,6 +1,6 @@
 package com.teamscale.client;
 
-import eu.cqse.teamscale.client.HttpUtils;
+import com.teamscale.client.HttpUtils;
 import okhttp3.HttpUrl;
 import okhttp3.Interceptor;
 import okhttp3.Request;


### PR DESCRIPTION
Changes (needed for the Jenkins plugin):

1. Allow external users of teamscale-client library to specify arbitrary EReportFormat values as a String
2. Allow external users of teamscale-client library to attach arbitrary Interceptors to Retrofit client

---

- [x] Changes are tested adequately - net needed
- [x] Agent's README.md updated in case of user-visible changes - not needed
- [x] CHANGELOG.md updated

Please respect the vote of the [Teamscale bot](https://demo.teamscale.com) or flag irrelevant findings as tolerated or false positives. If you feel that the Teamscale config needs adjustment, please state so in a comment and discuss this with your reviewer.

