### PR TITLE
Glob pattern matching in client

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ ext {
 	appVersion = '15.5.1' // Also update version in BuildVersion.kt
 	pluginVersion = '0.5.8' // Also update version in BuildVersion.kt
 	reportGeneratorVersion = '1.4.8'
-	teamscaleClientVersion = '0.3.4'
+	teamscaleClientVersion = '0.4.0'
 
 	// When upgrading JaCoCo to a newer version make sure to
 	// check the comment in the AnalyzerCache.java and CachingInstructionsBuilder.java


### PR DESCRIPTION
I'd like to reuse the logic for matching an ANT pattern against a working dir to obtain a list of files, so this moves it into the TS client's existing AntPatternUtils class.

- [ ] Changes are tested adequately - refactory only
- [ ] Agent's README.md updated in case of user-visible changes - not needed
- [ ] CHANGELOG.md updated - not needed, library change only

Please respect the vote of the [Teamscale bot](https://demo.teamscale.com) or flag irrelevant findings as tolerated or false positives. If you feel that the Teamscale config needs adjustment, please state so in a comment and discuss this with your reviewer.

