### PR TITLE
parse revision from git.properties instead of branch:timestamp

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -13,5 +13,5 @@
     </list>
   </component>
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="1.8" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK" />
 </project>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ We use [semantic versioning](http://semver.org/):
 - [breaking change] `--exclude` option in convert tool has been renamed to `--excludes`
 - [fix] Remove retry logic for impacted tests request
 - [fix] Resolve possible memory leak during report generation
+- [feature] Use git.commit.id from git.properties instead of branch and timestamp
 
 # 15.5.0
 - [feature] add TIA client library for integrating TIA in your custom test framework

--- a/agent/src/main/java/com/teamscale/jacoco/agent/git_properties/GitPropertiesLocator.java
+++ b/agent/src/main/java/com/teamscale/jacoco/agent/git_properties/GitPropertiesLocator.java
@@ -1,6 +1,5 @@
 package com.teamscale.jacoco.agent.git_properties;
 
-import com.teamscale.client.CommitDescriptor;
 import com.teamscale.client.StringUtils;
 import com.teamscale.jacoco.agent.upload.delay.DelayedCommitDescriptorUploader;
 import com.teamscale.jacoco.agent.util.DaemonThreadFactory;
@@ -12,7 +11,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.file.Paths;
-import java.time.format.DateTimeFormatter;
 import java.util.Properties;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
@@ -27,10 +25,6 @@ public class GitPropertiesLocator {
 
 	/** Name of the git.properties file. */
 	private static final String GIT_PROPERTIES_FILE_NAME = "git.properties";
-
-	/** The standard date format used by git.properties. */
-	private static final DateTimeFormatter GIT_PROPERTIES_DATE_FORMAT = DateTimeFormatter
-			.ofPattern("yyyy-MM-dd'T'HH:mm:ssZ");
 
 	private final Logger logger = LoggingUtils.getLogger(GitPropertiesLocator.class);
 	private final Executor executor;
@@ -72,7 +66,8 @@ public class GitPropertiesLocator {
 
 			if (foundRevision != null) {
 				if (!foundRevision.equals(revision)) {
-					logger.error("Found inconsistent git.properties files: {} contained SHA1 {} while {} contained {}." +
+					logger.error(
+							"Found inconsistent git.properties files: {} contained SHA1 {} while {} contained {}." +
 									" Please ensure that all git.properties files of your application are consistent." +
 									" Otherwise, you may" +
 									" be uploading to the wrong commit which will result in incorrect coverage data" +
@@ -95,8 +90,8 @@ public class GitPropertiesLocator {
 	}
 
 	/**
-	 * Reads the git SHA1 from the given jar file's git.properties and builds a commit descriptor out of
-	 * it. If no git.properties file can be found, returns null.
+	 * Reads the git SHA1 from the given jar file's git.properties and builds a commit descriptor out of it. If no
+	 * git.properties file can be found, returns null.
 	 *
 	 * @throws IOException                   If reading the jar file fails.
 	 * @throws InvalidGitPropertiesException If a git.properties file is found but it is malformed.

--- a/agent/src/main/java/com/teamscale/jacoco/agent/options/AgentOptions.java
+++ b/agent/src/main/java/com/teamscale/jacoco/agent/options/AgentOptions.java
@@ -199,7 +199,7 @@ public class AgentOptions {
 				"You did provide some options prefixed with 'teamscale-', but not all required ones!");
 
 		validator.isTrue(teamscaleServer.revision == null || teamscaleServer.commit == null,
-				"'teamscale-revision' is incompatible with 'teamscale-commit', 'teamscale-commit-manifest-jar', or 'teamscale-git-properties-jar'.");
+				"'teamscale-revision' is incompatible with 'teamscale-commit' and 'teamscale-commit-manifest-jar'.");
 
 		validator.isTrue((azureFileStorageConfig.hasAllRequiredFieldsSet() || azureFileStorageConfig
 						.hasAllRequiredFieldsNull()),
@@ -367,8 +367,8 @@ public class AgentOptions {
 
 	private IUploader createDelayedTeamscaleUploader(Instrumentation instrumentation) {
 		DelayedCommitDescriptorUploader store = new DelayedCommitDescriptorUploader(
-				commit -> {
-					teamscaleServer.commit = commit;
+				revision -> {
+					teamscaleServer.revision = revision;
 					return new TeamscaleUploader(teamscaleServer);
 				}, outputDirectory);
 		GitPropertiesLocator locator = new GitPropertiesLocator(store);

--- a/agent/src/main/java/com/teamscale/jacoco/agent/options/AgentOptionsParser.java
+++ b/agent/src/main/java/com/teamscale/jacoco/agent/options/AgentOptionsParser.java
@@ -243,7 +243,7 @@ public class AgentOptionsParser {
 				options.teamscaleServer.commit = getCommitFromManifest(parseFile(key, value));
 				return true;
 			case "teamscale-git-properties-jar":
-				options.teamscaleServer.commit = parseGitProperties(key, value);
+				options.teamscaleServer.revision = parseGitProperties(key, value);
 				return true;
 			case "teamscale-message":
 				options.teamscaleServer.message = value;
@@ -261,14 +261,14 @@ public class AgentOptionsParser {
 		}
 	}
 
-	private CommitDescriptor parseGitProperties(String key, String value) throws AgentOptionParseException {
+	private String parseGitProperties(String key, String value) throws AgentOptionParseException {
 		File jarFile = parseFile(key, value);
 		try {
-			CommitDescriptor commitDescriptor = GitPropertiesLocator.getCommitFromGitProperties(jarFile);
-			if (commitDescriptor == null) {
+			String commit = GitPropertiesLocator.getCommitFromGitProperties(jarFile);
+			if (commit == null) {
 				throw new AgentOptionParseException("Could not locate a git.properties file in " + jarFile.toString());
 			}
-			return commitDescriptor;
+			return commit;
 		} catch (IOException | InvalidGitPropertiesException e) {
 			throw new AgentOptionParseException("Could not locate a valid git.properties file in " + jarFile.toString(),
 					e);

--- a/agent/src/main/java/com/teamscale/jacoco/agent/upload/delay/DelayedCommitDescriptorUploader.java
+++ b/agent/src/main/java/com/teamscale/jacoco/agent/upload/delay/DelayedCommitDescriptorUploader.java
@@ -23,11 +23,11 @@ public class DelayedCommitDescriptorUploader implements IUploader {
 
 	private final Executor executor;
 	private final Logger logger = LoggingUtils.getLogger(this);
-	private final Function<CommitDescriptor, IUploader> wrappedUploaderFactory;
+	private final Function<String, IUploader> wrappedUploaderFactory;
 	private IUploader wrappedUploader = null;
-	private Path cacheDir;
+	private final Path cacheDir;
 
-	public DelayedCommitDescriptorUploader(Function<CommitDescriptor, IUploader> wrappedUploaderFactory,
+	public DelayedCommitDescriptorUploader(Function<String, IUploader> wrappedUploaderFactory,
 										   Path cacheDir) {
 		this(wrappedUploaderFactory, cacheDir, Executors.newSingleThreadExecutor(
 				new DaemonThreadFactory(DelayedCommitDescriptorUploader.class, "Delayed cache upload thread")));
@@ -37,7 +37,7 @@ public class DelayedCommitDescriptorUploader implements IUploader {
 	 * Visible for testing. Allows tests to control the {@link Executor} to test the asynchronous functionality of this
 	 * class.
 	 */
-	/*package*/ DelayedCommitDescriptorUploader(Function<CommitDescriptor, IUploader> wrappedUploaderFactory,
+	/*package*/ DelayedCommitDescriptorUploader(Function<String, IUploader> wrappedUploaderFactory,
 												Path cacheDir, Executor executor) {
 		this.wrappedUploaderFactory = wrappedUploaderFactory;
 		this.cacheDir = cacheDir;
@@ -83,7 +83,7 @@ public class DelayedCommitDescriptorUploader implements IUploader {
 	 * Sets the commit to upload the XMLs to and asynchronously triggers the upload of all cached XMLs. This method
 	 * should only be called once.
 	 */
-	public synchronized void setCommitAndTriggerAsynchronousUpload(CommitDescriptor commit) {
+	public synchronized void setCommitAndTriggerAsynchronousUpload(String commit) {
 		if (wrappedUploader == null) {
 			wrappedUploader = wrappedUploaderFactory.apply(commit);
 			logger.info("Commit to upload to has been found: {}. Uploading any cached XMLs now to {}", commit,

--- a/agent/src/test/java/com/teamscale/jacoco/agent/git_properties/GitPropertiesLocatorTest.java
+++ b/agent/src/test/java/com/teamscale/jacoco/agent/git_properties/GitPropertiesLocatorTest.java
@@ -1,6 +1,5 @@
 package com.teamscale.jacoco.agent.git_properties;
 
-import com.teamscale.client.CommitDescriptor;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
@@ -21,10 +20,9 @@ public class GitPropertiesLocatorTest {
 	public void testReadingGitPropertiesFromArchive() throws Exception {
 		for (String archiveName : TEST_ARCHIVES) {
 			JarInputStream jarInputStream = new JarInputStream(getClass().getResourceAsStream(archiveName));
-			CommitDescriptor commitDescriptor = GitPropertiesLocator
+			String commit = GitPropertiesLocator
 					.getCommitFromGitProperties(jarInputStream, new File("test.jar"));
-			assertThat(commitDescriptor).isNotNull();
-			assertThat(commitDescriptor.toString()).isEqualTo("master:1564065275000");
+			assertThat(commit).isEqualTo("72c7b3f7e6c4802414283cdf7622e6127f3f8976");
 		}
 	}
 
@@ -38,13 +36,4 @@ public class GitPropertiesLocatorTest {
 				.isInstanceOf(InvalidGitPropertiesException.class);
 	}
 
-	@Test
-	public void testGitPropertiesWithOrigin() throws InvalidGitPropertiesException {
-		Properties gitProperties = new Properties();
-		gitProperties.put("git.commit.time", "2020-01-01T00:00:00+0000");
-		gitProperties.put("git.branch", "origin/master");
-		CommitDescriptor commitDescriptor = GitPropertiesLocator
-				.parseGitPropertiesJarEntry("test", gitProperties, new File("test.jar"));
-		assertThat(commitDescriptor.branchName).isEqualTo("master");
-	}
 }

--- a/agent/src/test/java/com/teamscale/jacoco/agent/options/AgentOptionsTest.java
+++ b/agent/src/test/java/com/teamscale/jacoco/agent/options/AgentOptionsTest.java
@@ -120,8 +120,8 @@ public class AgentOptionsTest {
 	/** Tests that supplying both revision and commit info is forbidden. */
 	@Test
 	public void testBothRevisionAndCommitSupplied() throws URISyntaxException {
-		String message = "'teamscale-revision' is incompatible with 'teamscale-commit', "
-				+ "'teamscale-commit-manifest-jar', or 'teamscale-git-properties-jar'.";
+		String message = "'teamscale-revision' is incompatible with 'teamscale-commit' and "
+				+ "'teamscale-commit-manifest-jar'.";
 
 		File jar = new File(getClass().getResource("manifest-and-git-properties.jar").toURI());
 
@@ -132,10 +132,6 @@ public class AgentOptionsTest {
 		assertThatThrownBy(
 				() -> getAgentOptionsParserWithDummyLogger().parse(
 						"teamscale-revision=1234,teamscale-commit-manifest-jar=" + jar.getAbsolutePath()))
-				.isInstanceOf(AgentOptionParseException.class).hasMessageContaining(message);
-		assertThatThrownBy(
-				() -> getAgentOptionsParserWithDummyLogger().parse(
-						"teamscale-revision=1234,teamscale-git-properties-jar=" + jar.getAbsolutePath()))
 				.isInstanceOf(AgentOptionParseException.class).hasMessageContaining(message);
 	}
 

--- a/agent/src/test/java/com/teamscale/jacoco/agent/upload/delay/DelayedCommitDescriptorUploaderTest.java
+++ b/agent/src/test/java/com/teamscale/jacoco/agent/upload/delay/DelayedCommitDescriptorUploaderTest.java
@@ -44,7 +44,7 @@ public class DelayedCommitDescriptorUploaderTest {
 		InMemoryUploader destination = new InMemoryUploader();
 		DelayedCommitDescriptorUploader store = new DelayedCommitDescriptorUploader(commit -> destination, outputPath);
 
-		store.setCommitAndTriggerAsynchronousUpload(new CommitDescriptor("branch", 1234));
+		store.setCommitAndTriggerAsynchronousUpload("a2afb54566aaa");
 		store.upload(coverageFile);
 
 		assertThat(Files.list(outputPath).collect(Collectors.toList()))
@@ -64,7 +64,7 @@ public class DelayedCommitDescriptorUploaderTest {
 				executor);
 
 		store.upload(coverageFile);
-		store.setCommitAndTriggerAsynchronousUpload(new CommitDescriptor("branch", 1234));
+		store.setCommitAndTriggerAsynchronousUpload("a2afb54566aaa");
 		executor.shutdown();
 		executor.awaitTermination(5, TimeUnit.SECONDS);
 

--- a/agent/src/test/java/com/teamscale/jacoco/agent/upload/delay/DelayedCommitDescriptorUploaderTest.java
+++ b/agent/src/test/java/com/teamscale/jacoco/agent/upload/delay/DelayedCommitDescriptorUploaderTest.java
@@ -1,6 +1,5 @@
 package com.teamscale.jacoco.agent.upload.delay;
 
-import com.teamscale.client.CommitDescriptor;
 import com.teamscale.jacoco.agent.util.InMemoryUploader;
 import com.teamscale.report.jacoco.CoverageFile;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
Addresses issue TS-22986

- [x] Changes are tested adequately
- [x] Agent's README.md updated in case of user-visible changes
- [x] CHANGELOG.md updated

Please respect the vote of the [Teamscale bot](https://demo.teamscale.com) or flag irrelevant findings as tolerated or false positives. If you feel that the Teamscale config needs adjustment, please state so in a comment and discuss this with your reviewer.

