### PR TITLE
CR#26983 Delay testwise coverage generation to testrun/end and theref…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ We use [semantic versioning](http://semver.org/):
 
 # Next Release
 - [feature] _tia-client_: dynamically set partition and message
+- [fix] Upload to teamscale mode for testwise coverage did miss some class files when class-dir was not explicitly given
 
 # 21.3.0
 - [feature] _tia-client_: expose rank of tests

--- a/agent/src/main/java/com/teamscale/jacoco/agent/Agent.java
+++ b/agent/src/main/java/com/teamscale/jacoco/agent/Agent.java
@@ -20,6 +20,7 @@ import spark.Response;
 import spark.Service;
 
 import javax.servlet.http.HttpServletResponse;
+import java.io.File;
 import java.io.IOException;
 import java.lang.instrument.Instrumentation;
 import java.nio.file.Path;
@@ -130,20 +131,14 @@ public class Agent extends AgentBase {
 			return;
 		}
 
-		CoverageFile coverageFile;
-		long currentTime = System.currentTimeMillis();
-		Path outputPath = options.getOutputDirectory().resolve("jacoco-" + currentTime + ".xml");
-
 		try (Benchmark ignored = new Benchmark("Generating the XML report")) {
-			FileSystemUtils.ensureParentDirectoryExists(outputPath.toFile());
-			coverageFile = generator.convert(dump, outputPath);
+			File outputFile = options.createTempFile("jacoco",  "xml");
+			CoverageFile coverageFile = generator.convert(dump, outputFile);
+			uploader.upload(coverageFile);
 		} catch (IOException e) {
 			logger.error("Converting binary dump to XML failed", e);
-			return;
 		} catch (EmptyReportException e) {
 			logger.warn("No coverage was collected.", e);
-			return;
 		}
-		uploader.upload(coverageFile);
 	}
 }

--- a/agent/src/main/java/com/teamscale/jacoco/agent/Agent.java
+++ b/agent/src/main/java/com/teamscale/jacoco/agent/Agent.java
@@ -14,7 +14,6 @@ import com.teamscale.report.jacoco.CoverageFile;
 import com.teamscale.report.jacoco.EmptyReportException;
 import com.teamscale.report.jacoco.JaCoCoXmlReportGenerator;
 import com.teamscale.report.jacoco.dump.Dump;
-import org.conqat.lib.commons.filesystem.FileSystemUtils;
 import spark.Request;
 import spark.Response;
 import spark.Service;
@@ -23,7 +22,6 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.File;
 import java.io.IOException;
 import java.lang.instrument.Instrumentation;
-import java.nio.file.Path;
 import java.time.Duration;
 
 import static com.teamscale.jacoco.agent.util.LoggingUtils.wrap;
@@ -132,7 +130,7 @@ public class Agent extends AgentBase {
 		}
 
 		try (Benchmark ignored = new Benchmark("Generating the XML report")) {
-			File outputFile = options.createTempFile("jacoco",  "xml");
+			File outputFile = options.createTempFile("jacoco", "xml");
 			CoverageFile coverageFile = generator.convert(dump, outputFile);
 			uploader.upload(coverageFile);
 		} catch (IOException e) {

--- a/agent/src/main/java/com/teamscale/jacoco/agent/JacocoRuntimeController.java
+++ b/agent/src/main/java/com/teamscale/jacoco/agent/JacocoRuntimeController.java
@@ -78,7 +78,7 @@ public class JacocoRuntimeController {
 	public void dumpToFileAndReset(File file) throws IOException {
 		byte[] binaryData = agent.getExecutionData(true);
 
-		try (FileOutputStream outputStream = new FileOutputStream(file)) {
+		try (FileOutputStream outputStream = new FileOutputStream(file, true)) {
 			outputStream.write(binaryData);
 		}
 	}

--- a/agent/src/main/java/com/teamscale/jacoco/agent/JacocoRuntimeController.java
+++ b/agent/src/main/java/com/teamscale/jacoco/agent/JacocoRuntimeController.java
@@ -14,6 +14,9 @@ import org.jacoco.core.data.ISessionInfoVisitor;
 import org.jacoco.core.data.SessionInfo;
 
 import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
 import java.io.IOException;
 
 /**
@@ -69,6 +72,17 @@ public class JacocoRuntimeController {
 			throw new DumpException("should never happen for the ByteArrayInputStream", e);
 		}
 	}
+	/**
+	 * Dumps execution data to the given file and resets it afterwards.
+	 */
+	public void dumpToFileAndReset(File file) throws IOException {
+		byte[] binaryData = agent.getExecutionData(true);
+
+		try (FileOutputStream outputStream = new FileOutputStream(file)) {
+			outputStream.write(binaryData);
+		}
+	}
+
 
 	/**
 	 * Dumps execution data to a file and resets it.

--- a/agent/src/main/java/com/teamscale/jacoco/agent/JacocoRuntimeController.java
+++ b/agent/src/main/java/com/teamscale/jacoco/agent/JacocoRuntimeController.java
@@ -15,15 +15,13 @@ import org.jacoco.core.data.SessionInfo;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 
 /**
  * Wrapper around JaCoCo's {@link RT} runtime interface.
  * <p>
- * Can be used if the calling code is run in the same JVM as the agent is
- * attached to.
+ * Can be used if the calling code is run in the same JVM as the agent is attached to.
  */
 public class JacocoRuntimeController {
 
@@ -51,8 +49,8 @@ public class JacocoRuntimeController {
 	/**
 	 * Dumps execution data and resets it.
 	 *
-	 * @throws DumpException if dumping fails. This should never happen in real life. Dumping
-	 *                       should simply be retried later if this ever happens.
+	 * @throws DumpException if dumping fails. This should never happen in real life. Dumping should simply be retried
+	 *                       later if this ever happens.
 	 */
 	public Dump dumpAndReset() throws DumpException {
 		byte[] binaryData = agent.getExecutionData(true);
@@ -72,6 +70,7 @@ public class JacocoRuntimeController {
 			throw new DumpException("should never happen for the ByteArrayInputStream", e);
 		}
 	}
+
 	/**
 	 * Dumps execution data to the given file and resets it afterwards.
 	 */
@@ -87,8 +86,8 @@ public class JacocoRuntimeController {
 	/**
 	 * Dumps execution data to a file and resets it.
 	 *
-	 * @throws DumpException if dumping fails. This should never happen in real life. Dumping
-	 *                       should simply be retried later if this ever happens.
+	 * @throws DumpException if dumping fails. This should never happen in real life. Dumping should simply be retried
+	 *                       later if this ever happens.
 	 */
 	public void dump() throws DumpException {
 		try {
@@ -109,16 +108,14 @@ public class JacocoRuntimeController {
 	}
 
 	/**
-	 * Sets the current sessionId of the agent that can be used to identify
-	 * which coverage is recorded from now on.
+	 * Sets the current sessionId of the agent that can be used to identify which coverage is recorded from now on.
 	 */
 	public void setSessionId(String sessionId) {
 		agent.setSessionId(sessionId);
 	}
 
 	/**
-	 * Receives and stores a {@link SessionInfo}. Has a fallback dummy session in
-	 * case nothing is received.
+	 * Receives and stores a {@link SessionInfo}. Has a fallback dummy session in case nothing is received.
 	 */
 	private static class SessionInfoVisitor implements ISessionInfoVisitor {
 

--- a/agent/src/main/java/com/teamscale/jacoco/agent/convert/Converter.java
+++ b/agent/src/main/java/com/teamscale/jacoco/agent/convert/Converter.java
@@ -60,7 +60,7 @@ public class Converter {
 				wrap(logger));
 
 		try (Benchmark benchmark = new Benchmark("Generating the XML report")) {
-			generator.convert(new Dump(sessionInfo, executionDataStore), Paths.get(arguments.outputFile));
+			generator.convert(new Dump(sessionInfo, executionDataStore), Paths.get(arguments.outputFile).toFile());
 		} catch (EmptyReportException e) {
 			logger.warn("Converted report was emtpy.", e);
 		}

--- a/agent/src/main/java/com/teamscale/jacoco/agent/options/AgentOptions.java
+++ b/agent/src/main/java/com/teamscale/jacoco/agent/options/AgentOptions.java
@@ -38,6 +38,7 @@ import org.jacoco.core.runtime.WildcardMatcher;
 import org.slf4j.Logger;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.instrument.Instrumentation;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -424,6 +425,12 @@ public class AgentOptions {
 	 */
 	public Path getOutputDirectory() {
 		return outputDirectory;
+	}
+
+	/** Creates a new temp file with the given prefix, extension and current timestamp and ensures that the parent folder actually exists. */
+	public File createTempFile(String prefix, String extension) throws IOException {
+		org.conqat.lib.commons.filesystem.FileSystemUtils.ensureParentDirectoryExists(outputDirectory.toFile());
+		return outputDirectory.resolve(prefix + "-" + LocalDateTime.now().format(AgentOptions.DATE_TIME_FORMATTER) + "." + extension).toFile();
 	}
 
 	/**

--- a/agent/src/main/java/com/teamscale/jacoco/agent/options/AgentOptions.java
+++ b/agent/src/main/java/com/teamscale/jacoco/agent/options/AgentOptions.java
@@ -429,7 +429,7 @@ public class AgentOptions {
 
 	/** Creates a new temp file with the given prefix, extension and current timestamp and ensures that the parent folder actually exists. */
 	public File createTempFile(String prefix, String extension) throws IOException {
-		org.conqat.lib.commons.filesystem.FileSystemUtils.ensureParentDirectoryExists(outputDirectory.toFile());
+		org.conqat.lib.commons.filesystem.FileSystemUtils.ensureDirectoryExists(outputDirectory.toFile());
 		return outputDirectory.resolve(prefix + "-" + LocalDateTime.now().format(AgentOptions.DATE_TIME_FORMATTER) + "." + extension).toFile();
 	}
 

--- a/agent/src/main/java/com/teamscale/jacoco/agent/options/AgentOptions.java
+++ b/agent/src/main/java/com/teamscale/jacoco/agent/options/AgentOptions.java
@@ -430,7 +430,7 @@ public class AgentOptions {
 	/** Creates a new temp file with the given prefix, extension and current timestamp and ensures that the parent folder actually exists. */
 	public File createTempFile(String prefix, String extension) throws IOException {
 		org.conqat.lib.commons.filesystem.FileSystemUtils.ensureDirectoryExists(outputDirectory.toFile());
-		return outputDirectory.resolve(prefix + "-" + LocalDateTime.now().format(AgentOptions.DATE_TIME_FORMATTER) + "." + extension).toFile();
+		return outputDirectory.resolve(prefix + "-" + LocalDateTime.now().format(DATE_TIME_FORMATTER) + "." + extension).toFile();
 	}
 
 	/**

--- a/agent/src/main/java/com/teamscale/jacoco/agent/testimpact/CoverageToTeamscaleStrategy.java
+++ b/agent/src/main/java/com/teamscale/jacoco/agent/testimpact/CoverageToTeamscaleStrategy.java
@@ -7,7 +7,6 @@ import com.teamscale.client.EReportFormat;
 import com.teamscale.jacoco.agent.JacocoRuntimeController;
 import com.teamscale.jacoco.agent.options.AgentOptions;
 import com.teamscale.jacoco.agent.util.LoggingUtils;
-import com.teamscale.report.jacoco.dump.Dump;
 import com.teamscale.report.testwise.jacoco.JaCoCoTestwiseReportGenerator;
 import com.teamscale.report.testwise.jacoco.cache.CoverageGenerationException;
 import com.teamscale.report.testwise.model.TestExecution;
@@ -15,8 +14,10 @@ import com.teamscale.report.testwise.model.TestwiseCoverage;
 import com.teamscale.report.testwise.model.TestwiseCoverageReport;
 import com.teamscale.report.testwise.model.builder.TestCoverageBuilder;
 import com.teamscale.report.testwise.model.builder.TestwiseCoverageReportBuilder;
+import org.conqat.lib.commons.filesystem.FileSystemUtils;
 import org.slf4j.Logger;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -25,7 +26,7 @@ import static java.util.stream.Collectors.toList;
 
 /**
  * Strategy that records test-wise coverage and uploads the resulting report to Teamscale. Also handles the {@link
- * #testRunStart(List, boolean, Long)} event by retrieving tests to run from Teamscale.
+ * #testRunStart(List, boolean, String)} event by retrieving tests to run from Teamscale.
  */
 public class CoverageToTeamscaleStrategy extends TestEventHandlerStrategyBase {
 
@@ -34,7 +35,11 @@ public class CoverageToTeamscaleStrategy extends TestEventHandlerStrategyBase {
 	private final JsonAdapter<TestwiseCoverageReport> testwiseCoverageReportJsonAdapter = new Moshi.Builder().build()
 			.adapter(TestwiseCoverageReport.class);
 
-	private final TestwiseCoverage testwiseCoverage = new TestwiseCoverage();
+	/**
+	 * The path to the exec file into which the coverage of the current test run is appended to. Will be null if there
+	 * is no file for the current test run yet.
+	 */
+	private File testExecFile;
 	private final List<TestExecution> testExecutions = new ArrayList<>();
 	private List<ClusteredTestDetails> availableTests = new ArrayList<>();
 	private final JaCoCoTestwiseReportGenerator reportGenerator;
@@ -77,15 +82,28 @@ public class CoverageToTeamscaleStrategy extends TestEventHandlerStrategyBase {
 	public String testEnd(String test,
 						  TestExecution testExecution) throws JacocoRuntimeController.DumpException, CoverageGenerationException {
 		super.testEnd(test, testExecution);
-
 		testExecutions.add(testExecution);
-		Dump dump = controller.dumpAndReset();
-		testwiseCoverage.add(reportGenerator.convert(dump));
+
+		try {
+			if (testExecFile == null) {
+				testExecFile = agentOptions.createTempFile("coverage", "exec");
+				testExecFile.deleteOnExit();
+			}
+			controller.dumpToFileAndReset(testExecFile);
+		} catch (IOException e) {
+			throw new JacocoRuntimeController.DumpException("Failed to write coverage to disk into " + testExecFile + "!",
+					e);
+		}
 		return null;
 	}
 
 	@Override
-	public void testRunEnd() throws IOException {
+	public void testRunEnd() throws IOException, CoverageGenerationException {
+		if (testExecFile == null) {
+			logger.warn("Tried to end a test run that contained no tests!");
+			return;
+		}
+
 		List<String> executionUniformPaths = testExecutions.stream().map(execution -> {
 			if (execution == null) {
 				return null;
@@ -93,6 +111,8 @@ public class CoverageToTeamscaleStrategy extends TestEventHandlerStrategyBase {
 				return execution.getUniformPath();
 			}
 		}).collect(toList());
+
+		TestwiseCoverage testwiseCoverage = reportGenerator.convert(testExecFile);
 		logger.debug("Creating testwise coverage for available tests `{}`, test executions `{}` and coverage for `{}`",
 				availableTests.stream().map(test -> test.uniformPath).collect(toList()),
 				executionUniformPaths,
@@ -101,12 +121,23 @@ public class CoverageToTeamscaleStrategy extends TestEventHandlerStrategyBase {
 		TestwiseCoverageReport report = TestwiseCoverageReportBuilder
 				.createFrom(availableTests, testwiseCoverage.getTests(), testExecutions);
 
-		String json = testwiseCoverageReportJsonAdapter.toJson(report);
-		teamscaleClient
-				.uploadReport(EReportFormat.TESTWISE_COVERAGE, json, agentOptions.getTeamscaleServerOptions().commit,
-						agentOptions.getTeamscaleServerOptions().revision,
-						agentOptions.getTeamscaleServerOptions().partition,
-						agentOptions.getTeamscaleServerOptions().getMessage());
+		String testwiseCoverageJson = testwiseCoverageReportJsonAdapter.toJson(report);
+		try {
+			teamscaleClient
+					.uploadReport(EReportFormat.TESTWISE_COVERAGE, testwiseCoverageJson,
+							agentOptions.getTeamscaleServerOptions().commit,
+							agentOptions.getTeamscaleServerOptions().revision,
+							agentOptions.getTeamscaleServerOptions().partition,
+							agentOptions.getTeamscaleServerOptions().getMessage());
+		} catch (IOException e) {
+			File reportFile = agentOptions.createTempFile("testwise-coverage", "json");
+			FileSystemUtils.writeFileUTF8(reportFile, testwiseCoverageJson);
+			String errorMessage = "Failed to upload coverage to Teamscale! Report is stored in " + reportFile + "!";
+			logger.error(errorMessage, e);
+			throw new IOException(errorMessage, e);
+		}
+		testExecFile.delete();
+		testExecFile = null;
 	}
 
 }

--- a/agent/src/main/java/com/teamscale/jacoco/agent/testimpact/TestEventHandlerStrategyBase.java
+++ b/agent/src/main/java/com/teamscale/jacoco/agent/testimpact/TestEventHandlerStrategyBase.java
@@ -126,7 +126,7 @@ public abstract class TestEventHandlerStrategyBase {
 	 * Signals that the test run has ended. Strategies that support this can upload a report via the {@link
 	 * #teamscaleClient} here.
 	 */
-	public void testRunEnd() throws IOException {
+	public void testRunEnd() throws IOException, CoverageGenerationException {
 		throw new UnsupportedOperationException("You configured the agent in a mode that does not support uploading " +
 				"reports to Teamscale. Please configure 'tia-mode=teamscale-upload' or simply don't call" +
 				"POST /testrun/end.");

--- a/agent/src/main/java/com/teamscale/jacoco/agent/testimpact/TestwiseCoverageAgent.java
+++ b/agent/src/main/java/com/teamscale/jacoco/agent/testimpact/TestwiseCoverageAgent.java
@@ -129,7 +129,7 @@ public class TestwiseCoverageAgent extends AgentBase {
 		return responseBody;
 	}
 
-	private String handleTestRunEnd(Request request, Response response) throws IOException {
+	private String handleTestRunEnd(Request request, Response response) throws IOException, CoverageGenerationException {
 		testEventHandler.testRunEnd();
 		response.status(SC_NO_CONTENT);
 		return "";

--- a/agent/src/test/java/com/teamscale/jacoco/agent/testimpact/CoverageToTeamscaleStrategyTest.java
+++ b/agent/src/test/java/com/teamscale/jacoco/agent/testimpact/CoverageToTeamscaleStrategyTest.java
@@ -56,12 +56,7 @@ public class CoverageToTeamscaleStrategyTest {
 		AgentOptions options = mockOptions();
 		CoverageToTeamscaleStrategy strategy = new CoverageToTeamscaleStrategy(controller, options, reportGenerator);
 
-		TestCoverageBuilder testCoverageBuilder = new TestCoverageBuilder("mytest");
-		FileCoverageBuilder fileCoverageBuilder = new FileCoverageBuilder("src/main/java", "Main.java");
-		fileCoverageBuilder.addLineRange(1, 4);
-		testCoverageBuilder.add(fileCoverageBuilder);
-		TestwiseCoverage testwiseCoverage = new TestwiseCoverage();
-		testwiseCoverage.add(testCoverageBuilder);
+		TestwiseCoverage testwiseCoverage = getDummyTestwiseCoverage("mytest");
 		when(reportGenerator.convert(any(File.class))).thenReturn(testwiseCoverage);
 
 		// we skip testRunStart and don't provide any available tests
@@ -81,12 +76,7 @@ public class CoverageToTeamscaleStrategyTest {
 						Collections.singletonList(new PrioritizableTest("mytest"))));
 		when(client.getImpactedTests(any(), any(), any(), any(), anyBoolean())).thenReturn(Response.success(clusters));
 
-		TestCoverageBuilder testCoverageBuilder = new TestCoverageBuilder("mytest");
-		FileCoverageBuilder fileCoverageBuilder = new FileCoverageBuilder("src/main/java", "Main.java");
-		fileCoverageBuilder.addLineRange(1, 4);
-		testCoverageBuilder.add(fileCoverageBuilder);
-		TestwiseCoverage testwiseCoverage = new TestwiseCoverage();
-		testwiseCoverage.add(testCoverageBuilder);
+		TestwiseCoverage testwiseCoverage = getDummyTestwiseCoverage("mytest");
 		when(reportGenerator.convert(any(File.class))).thenReturn(testwiseCoverage);
 
 		AgentOptions options = mockOptions();
@@ -103,6 +93,16 @@ public class CoverageToTeamscaleStrategyTest {
 		verify(client).uploadReport(eq(EReportFormat.TESTWISE_COVERAGE),
 				matches("\\Q{\"tests\":[{\"content\":\"content\",\"duration\":\\E[^,]*\\Q,\"paths\":[{\"files\":[{\"coveredLines\":\"1-4\",\"fileName\":\"Main.java\"}],\"path\":\"src/main/java\"}],\"result\":\"PASSED\",\"sourcePath\":\"mytest\",\"uniformPath\":\"mytest\"}]}\\E"),
 				any(), any(), any(), any());
+	}
+
+	protected static TestwiseCoverage getDummyTestwiseCoverage(String test) {
+		TestCoverageBuilder testCoverageBuilder = new TestCoverageBuilder(test);
+		FileCoverageBuilder fileCoverageBuilder = new FileCoverageBuilder("src/main/java", "Main.java");
+		fileCoverageBuilder.addLineRange(1, 4);
+		testCoverageBuilder.add(fileCoverageBuilder);
+		TestwiseCoverage testwiseCoverage = new TestwiseCoverage();
+		testwiseCoverage.add(testCoverageBuilder);
+		return testwiseCoverage;
 	}
 
 	private AgentOptions mockOptions() throws IOException {

--- a/agent/src/test/java/com/teamscale/jacoco/agent/testimpact/CoverageToTeamscaleStrategyTest.java
+++ b/agent/src/test/java/com/teamscale/jacoco/agent/testimpact/CoverageToTeamscaleStrategyTest.java
@@ -9,21 +9,22 @@ import com.teamscale.client.TeamscaleClient;
 import com.teamscale.client.TeamscaleServer;
 import com.teamscale.jacoco.agent.JacocoRuntimeController;
 import com.teamscale.jacoco.agent.options.AgentOptions;
-import com.teamscale.report.jacoco.dump.Dump;
 import com.teamscale.report.testwise.jacoco.JaCoCoTestwiseReportGenerator;
 import com.teamscale.report.testwise.model.ETestExecutionResult;
 import com.teamscale.report.testwise.model.TestExecution;
+import com.teamscale.report.testwise.model.TestwiseCoverage;
 import com.teamscale.report.testwise.model.builder.FileCoverageBuilder;
 import com.teamscale.report.testwise.model.builder.TestCoverageBuilder;
 import okhttp3.HttpUrl;
-import org.jacoco.core.data.ExecutionDataStore;
-import org.jacoco.core.data.SessionInfo;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import retrofit2.Response;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 
@@ -47,10 +48,11 @@ public class CoverageToTeamscaleStrategyTest {
 	@Mock
 	private JacocoRuntimeController controller;
 
+	@TempDir
+	File tempDir;
+
 	@Test
 	public void shouldRecordCoverageForTestsEvenIfNotProvidedAsAvailableTest() throws Exception {
-		when(controller.dumpAndReset()).thenReturn(new Dump(new SessionInfo("mytest", 0, 0), new ExecutionDataStore()));
-
 		AgentOptions options = mockOptions();
 		CoverageToTeamscaleStrategy strategy = new CoverageToTeamscaleStrategy(controller, options, reportGenerator);
 
@@ -58,7 +60,9 @@ public class CoverageToTeamscaleStrategyTest {
 		FileCoverageBuilder fileCoverageBuilder = new FileCoverageBuilder("src/main/java", "Main.java");
 		fileCoverageBuilder.addLineRange(1, 4);
 		testCoverageBuilder.add(fileCoverageBuilder);
-		when(reportGenerator.convert(any(Dump.class))).thenReturn(testCoverageBuilder);
+		TestwiseCoverage testwiseCoverage = new TestwiseCoverage();
+		testwiseCoverage.add(testCoverageBuilder);
+		when(reportGenerator.convert(any(File.class))).thenReturn(testwiseCoverage);
 
 		// we skip testRunStart and don't provide any available tests
 		strategy.testStart("mytest");
@@ -81,10 +85,12 @@ public class CoverageToTeamscaleStrategyTest {
 		FileCoverageBuilder fileCoverageBuilder = new FileCoverageBuilder("src/main/java", "Main.java");
 		fileCoverageBuilder.addLineRange(1, 4);
 		testCoverageBuilder.add(fileCoverageBuilder);
-		when(reportGenerator.convert(any(Dump.class))).thenReturn(testCoverageBuilder);
+		TestwiseCoverage testwiseCoverage = new TestwiseCoverage();
+		testwiseCoverage.add(testCoverageBuilder);
+		when(reportGenerator.convert(any(File.class))).thenReturn(testwiseCoverage);
 
 		AgentOptions options = mockOptions();
-		JacocoRuntimeController controller = mockController();
+		JacocoRuntimeController controller = mock(JacocoRuntimeController.class);
 		CoverageToTeamscaleStrategy strategy = new CoverageToTeamscaleStrategy(controller, options, reportGenerator);
 
 		strategy.testRunStart(
@@ -99,15 +105,10 @@ public class CoverageToTeamscaleStrategyTest {
 				any(), any(), any(), any());
 	}
 
-	private JacocoRuntimeController mockController() throws JacocoRuntimeController.DumpException {
-		JacocoRuntimeController controller = mock(JacocoRuntimeController.class);
-		when(controller.dumpAndReset()).thenReturn(new Dump(new SessionInfo("mytest", 0, 0), new ExecutionDataStore()));
-		return controller;
-	}
-
-	private AgentOptions mockOptions() {
+	private AgentOptions mockOptions() throws IOException {
 		AgentOptions options = mock(AgentOptions.class);
 		when(options.createTeamscaleClient()).thenReturn(client);
+		when(options.createTempFile(any(), any())).thenReturn(new File(tempDir, "test"));
 
 		TeamscaleServer server = new TeamscaleServer();
 		server.commit = new CommitDescriptor("branch", "12345");

--- a/agent/src/test/java/com/teamscale/jacoco/agent/testimpact/CoverageToTeamscaleStrategyTest.java
+++ b/agent/src/test/java/com/teamscale/jacoco/agent/testimpact/CoverageToTeamscaleStrategyTest.java
@@ -95,6 +95,7 @@ public class CoverageToTeamscaleStrategyTest {
 				any(), any(), any(), any());
 	}
 
+	/** Returns a dummy testwise coverage object for a test with the given name that covers a few lines of Main.java. */
 	protected static TestwiseCoverage getDummyTestwiseCoverage(String test) {
 		TestCoverageBuilder testCoverageBuilder = new TestCoverageBuilder(test);
 		FileCoverageBuilder fileCoverageBuilder = new FileCoverageBuilder("src/main/java", "Main.java");

--- a/agent/src/test/java/com/teamscale/jacoco/agent/testimpact/TestwiseCoverageAgentTest.java
+++ b/agent/src/test/java/com/teamscale/jacoco/agent/testimpact/TestwiseCoverageAgentTest.java
@@ -86,7 +86,9 @@ public class TestwiseCoverageAgentTest {
 		when(reportGenerator.convert(any(File.class))).thenReturn(testwiseCoverage);
 
 		int port = PORT_COUNTER.incrementAndGet();
-		new TestwiseCoverageAgent(mockOptions(port), null, reportGenerator);
+		AgentOptions options = mockOptions(port);
+		when(options.createTempFile(any(), any())).thenReturn(new File(tempDir, "test"));
+		new TestwiseCoverageAgent(options, null, reportGenerator);
 
 		TiaAgent agent = new TiaAgent(false, HttpUrl.get("http://localhost:" + port));
 
@@ -141,10 +143,9 @@ public class TestwiseCoverageAgentTest {
 		assertThat(tests.get(0).tests).hasSize(1);
 	}
 
-	private AgentOptions mockOptions(int port) throws IOException {
+	private AgentOptions mockOptions(int port) {
 		AgentOptions options = mock(AgentOptions.class);
 		when(options.createTeamscaleClient()).thenReturn(client);
-		when(options.createTempFile(any(), any())).thenReturn(new File(tempDir, "test"));
 
 		TeamscaleServer server = new TeamscaleServer();
 		server.commit = new CommitDescriptor("branch", "12345");

--- a/agent/src/test/java/com/teamscale/jacoco/agent/testimpact/TestwiseCoverageAgentTest.java
+++ b/agent/src/test/java/com/teamscale/jacoco/agent/testimpact/TestwiseCoverageAgentTest.java
@@ -9,7 +9,6 @@ import com.teamscale.client.TeamscaleClient;
 import com.teamscale.client.TeamscaleServer;
 import com.teamscale.jacoco.agent.options.AgentOptions;
 import com.teamscale.jacoco.agent.options.ETestwiseCoverageMode;
-import com.teamscale.report.jacoco.dump.Dump;
 import com.teamscale.report.testwise.jacoco.JaCoCoTestwiseReportGenerator;
 import com.teamscale.report.testwise.model.ETestExecutionResult;
 import com.teamscale.report.testwise.model.TestwiseCoverage;
@@ -33,7 +32,6 @@ import retrofit2.http.POST;
 import retrofit2.http.Query;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;

--- a/agent/src/test/java/com/teamscale/jacoco/agent/testimpact/TestwiseCoverageAgentTest.java
+++ b/agent/src/test/java/com/teamscale/jacoco/agent/testimpact/TestwiseCoverageAgentTest.java
@@ -11,9 +11,6 @@ import com.teamscale.jacoco.agent.options.AgentOptions;
 import com.teamscale.jacoco.agent.options.ETestwiseCoverageMode;
 import com.teamscale.report.testwise.jacoco.JaCoCoTestwiseReportGenerator;
 import com.teamscale.report.testwise.model.ETestExecutionResult;
-import com.teamscale.report.testwise.model.TestwiseCoverage;
-import com.teamscale.report.testwise.model.builder.FileCoverageBuilder;
-import com.teamscale.report.testwise.model.builder.TestCoverageBuilder;
 import com.teamscale.tia.client.RunningTest;
 import com.teamscale.tia.client.TestRun;
 import com.teamscale.tia.client.TestRunWithClusteredSuggestions;
@@ -75,13 +72,8 @@ public class TestwiseCoverageAgentTest {
 		when(client.getImpactedTests(any(), any(), any(), any(), anyBoolean()))
 				.thenReturn(Response.success(impactedClusters));
 
-		TestCoverageBuilder testCoverageBuilder = new TestCoverageBuilder("test2");
-		FileCoverageBuilder fileCoverageBuilder = new FileCoverageBuilder("src/main/java", "Main.java");
-		fileCoverageBuilder.addLineRange(1, 4);
-		testCoverageBuilder.add(fileCoverageBuilder);
-		TestwiseCoverage testwiseCoverage = new TestwiseCoverage();
-		testwiseCoverage.add(testCoverageBuilder);
-		when(reportGenerator.convert(any(File.class))).thenReturn(testwiseCoverage);
+		when(reportGenerator.convert(any(File.class)))
+				.thenReturn(CoverageToTeamscaleStrategyTest.getDummyTestwiseCoverage("test2"));
 
 		int port = PORT_COUNTER.incrementAndGet();
 		AgentOptions options = mockOptions(port);

--- a/report-generator/src/main/java/com/teamscale/report/jacoco/JaCoCoXmlReportGenerator.java
+++ b/report-generator/src/main/java/com/teamscale/report/jacoco/JaCoCoXmlReportGenerator.java
@@ -4,7 +4,6 @@ import com.teamscale.report.EDuplicateClassFileBehavior;
 import com.teamscale.report.jacoco.dump.Dump;
 import com.teamscale.report.util.ClasspathWildcardIncludeFilter;
 import com.teamscale.report.util.ILogger;
-
 import org.jacoco.core.analysis.Analyzer;
 import org.jacoco.core.analysis.CoverageBuilder;
 import org.jacoco.core.analysis.IBundleCoverage;
@@ -16,7 +15,6 @@ import org.jacoco.report.xml.XMLFormatter;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
 
@@ -39,7 +37,7 @@ public class JaCoCoXmlReportGenerator {
 
 	/** Whether to remove uncovered classes from the report. */
 	private final boolean ignoreUncoveredClasses;
-	
+
 	/** Part of the error message logged when validating the coverage report fails. */
 	private static final String MOST_LIKELY_CAUSE_MESSAGE = "Most likely you did not configure the agent correctly." +
 			" Please check that the includes and excludes options are set correctly so the relevant code is included." +
@@ -49,7 +47,8 @@ public class JaCoCoXmlReportGenerator {
 
 	public JaCoCoXmlReportGenerator(List<File> codeDirectoriesOrArchives,
 									ClasspathWildcardIncludeFilter locationIncludeFilter,
-									EDuplicateClassFileBehavior duplicateClassFileBehavior, boolean ignoreUncoveredClasses, ILogger logger) {
+									EDuplicateClassFileBehavior duplicateClassFileBehavior,
+									boolean ignoreUncoveredClasses, ILogger logger) {
 		this.codeDirectoriesOrArchives = codeDirectoriesOrArchives;
 		this.duplicateClassFileBehavior = duplicateClassFileBehavior;
 		this.locationIncludeFilter = locationIncludeFilter;
@@ -74,7 +73,7 @@ public class JaCoCoXmlReportGenerator {
 		ExecutionDataStore mergedStore = dump.store;
 		IBundleCoverage bundleCoverage = analyzeStructureAndAnnotateCoverage(mergedStore);
 		checkForEmptyReport(bundleCoverage);
-		try(OutputStream outputStream = coverageFile.getOutputStream()) {
+		try (OutputStream outputStream = coverageFile.getOutputStream()) {
 			createReport(outputStream, bundleCoverage, dump.info, mergedStore);
 		}
 	}

--- a/report-generator/src/main/java/com/teamscale/report/jacoco/JaCoCoXmlReportGenerator.java
+++ b/report-generator/src/main/java/com/teamscale/report/jacoco/JaCoCoXmlReportGenerator.java
@@ -63,8 +63,8 @@ public class JaCoCoXmlReportGenerator {
 	 *
 	 * @return The file object of for the converted report or null if it could not be created
 	 */
-	public CoverageFile convert(Dump dump, Path filePath) throws IOException, EmptyReportException {
-		CoverageFile coverageFile = new CoverageFile(filePath.toFile());
+	public CoverageFile convert(Dump dump, File filePath) throws IOException, EmptyReportException {
+		CoverageFile coverageFile = new CoverageFile(filePath);
 		convertToReport(coverageFile, dump);
 		return coverageFile;
 	}

--- a/report-generator/src/main/java/com/teamscale/report/testwise/jacoco/CachingExecutionDataReader.java
+++ b/report-generator/src/main/java/com/teamscale/report/testwise/jacoco/CachingExecutionDataReader.java
@@ -41,10 +41,9 @@ class CachingExecutionDataReader {
 	 * Analyzes the class/jar/war/... files and creates a lookup of which probes belong to which method.
 	 */
 	private void analyzeClassDirs() throws CoverageGenerationException {
-		if (probesCache != null) {
-			return;
+		if (probesCache == null) {
+			probesCache = new ProbesCache(logger, duplicateClassFileBehavior);
 		}
-		probesCache = new ProbesCache(logger, duplicateClassFileBehavior);
 		AnalyzerCache analyzer = new AnalyzerCache(probesCache, locationIncludeFilter, logger);
 		for (File classDir : classesDirectories) {
 			if (classDir.exists()) {

--- a/report-generator/src/main/java/com/teamscale/report/testwise/jacoco/JaCoCoTestwiseReportGenerator.java
+++ b/report-generator/src/main/java/com/teamscale/report/testwise/jacoco/JaCoCoTestwiseReportGenerator.java
@@ -32,7 +32,7 @@ import java.util.function.Consumer;
 public class JaCoCoTestwiseReportGenerator {
 
 	/** The execution data reader and converter. */
-	private CachingExecutionDataReader executionDataReader;
+	private final CachingExecutionDataReader executionDataReader;
 
 	/** The filter for the analyzed class files. */
 	private final ClasspathWildcardIncludeFilter locationIncludeFilter;
@@ -106,7 +106,7 @@ public class JaCoCoTestwiseReportGenerator {
 		private ExecutionDataStore store;
 
 		/** The consumer to pass {@link Dump}s to. */
-		private Consumer<Dump> dumpConsumer;
+		private final Consumer<Dump> dumpConsumer;
 
 		private DumpCallback(Consumer<Dump> dumpConsumer) {
 			this.dumpConsumer = dumpConsumer;

--- a/report-generator/src/test/java/com/teamscale/report/jacoco/JaCoCoXmlReportGeneratorTest.java
+++ b/report-generator/src/test/java/com/teamscale/report/jacoco/JaCoCoXmlReportGeneratorTest.java
@@ -164,6 +164,6 @@ public class JaCoCoXmlReportGeneratorTest extends TestDataBase {
 		String outputFilePath = "test-coverage-" + currentTime + ".xml";
 		return new JaCoCoXmlReportGenerator(Collections.singletonList(classFileFolder), filter,
 				duplicateClassFileBehavior, ignoreUncoveredClasses,
-				mock(ILogger.class)).convert(dump, Paths.get(outputFilePath));
+				mock(ILogger.class)).convert(dump, Paths.get(outputFilePath).toFile());
 	}
 }


### PR DESCRIPTION
Delay testwise coverage generation to testrun/end and therefore make it reasonable to rescan the classes dir on report generation

Addresses issue [TS-26983](https://cqse.atlassian.net/browse/TS-26983)

- [ ] Changes are tested adequately
- [ ] Agent's README.md updated in case of user-visible changes
- [ ] CHANGELOG.md updated
- [ ] Present new features in [N&N](https://wiki.cqse.eu/pages/viewpage.action?pageId=689566)
- [ ] [TGA Tutorial](https://docs.teamscale.com/tutorial/setting-up-tga-java) updated
- [ ] [TIA Tutorial](https://docs.teamscale.com/tutorial/tia-java/) updated

Please respect the vote of the [Teamscale bot](https://demo.teamscale.com) or flag irrelevant findings as tolerated or false positives. If you feel that the Teamscale config needs adjustment, please state so in a comment and discuss this with your reviewer.

