### PR TITLE
CR#27492 Increase default timeout for connection to Teamscale JaCoCo agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ We use [semantic versioning](http://semver.org/):
 - PATCH version when you make backwards compatible bug fixes.
 
 # Next Release
+- [fix] _tia-client_: Increased timout for connection to Teamscale JaCoCo agent
 
 # 21.6.0
 - [feature] Support for Java 16 (and experimental support for Java 17)

--- a/tia-client/src/main/java/com/teamscale/tia.client/ITestwiseCoverageAgentApi.java
+++ b/tia-client/src/main/java/com/teamscale/tia.client/ITestwiseCoverageAgentApi.java
@@ -4,6 +4,7 @@ import com.teamscale.client.ClusteredTestDetails;
 import com.teamscale.client.PrioritizableTestCluster;
 import com.teamscale.report.testwise.model.TestExecution;
 import okhttp3.HttpUrl;
+import okhttp3.OkHttpClient;
 import okhttp3.ResponseBody;
 import retrofit2.Call;
 import retrofit2.Retrofit;
@@ -15,6 +16,7 @@ import retrofit2.http.Path;
 import retrofit2.http.Query;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 /** {@link Retrofit} API specification for the JaCoCo agent in test-wise coverage mode. */
 public interface ITestwiseCoverageAgentApi {
@@ -65,9 +67,14 @@ public interface ITestwiseCoverageAgentApi {
 	 * and which sets the Accept header to JSON.
 	 */
 	static ITestwiseCoverageAgentApi createService(HttpUrl baseUrl) {
+		OkHttpClient.Builder httpClientBuilder = new OkHttpClient.Builder();
+		httpClientBuilder.connectTimeout(60, TimeUnit.SECONDS);
+		httpClientBuilder.readTimeout(120, TimeUnit.SECONDS);
+		httpClientBuilder.writeTimeout(60, TimeUnit.SECONDS);
 		Retrofit retrofit = new Retrofit.Builder()
-				.baseUrl(baseUrl)
-				.addConverterFactory(MoshiConverterFactory.create())
+				.client(httpClientBuilder.build()) //
+				.baseUrl(baseUrl) //
+				.addConverterFactory(MoshiConverterFactory.create()) //
 				.build();
 		return retrofit.create(ITestwiseCoverageAgentApi.class);
 	}


### PR DESCRIPTION
Addresses issue [TS-27492](https://cqse.atlassian.net/browse/TS-27492)

- [ ] Changes are tested adequately
- [ ] Agent's README.md updated in case of user-visible changes
- [x] CHANGELOG.md updated
- [ ] Present new features in [N&N](https://wiki.cqse.eu/pages/viewpage.action?pageId=689566)
- [ ] [TGA Tutorial](https://docs.teamscale.com/tutorial/setting-up-tga-java) updated
- [ ] [TIA Tutorial](https://docs.teamscale.com/tutorial/tia-java/) updated

Please respect the vote of the [Teamscale bot](https://demo.teamscale.com) or flag irrelevant findings as tolerated or false positives. If you feel that the Teamscale config needs adjustment, please state so in a comment and discuss this with your reviewer.

