### PR TITLE
prevent NPE when a boolean test engine option is not specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ We use [semantic versioning](http://semver.org/):
 # New Release
 
 - [feature] The agent logs now an error with further information when dumped coverage is empty
-- [fix] Bot specifying a boolean option for the JUnit 5 impacted test engine caused an NPE
+- [fix] Not specifying certain options for the JUnit 5 impacted test engine caused an NPE
 
 # 22.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ We use [semantic versioning](http://semver.org/):
 # New Release
 
 - [feature] The agent logs now an error with further information when dumped coverage is empty
+- [fix] Bot specifying a boolean option for the JUnit 5 impacted test engine caused an NPE
 
 # 22.2.0
 

--- a/impacted-test-engine/src/main/java/com/teamscale/test_impacted/engine/options/TestEngineOptionUtils.java
+++ b/impacted-test-engine/src/main/java/com/teamscale/test_impacted/engine/options/TestEngineOptionUtils.java
@@ -68,24 +68,24 @@ public class TestEngineOptionUtils {
 			this.configurationParameters = configurationParameters;
 		}
 
-		private <T> T get(String propertyName, Function<String, T> mapper) {
-			return configurationParameters.get(prefix + propertyName).map(mapper).orElse(null);
+		private <T> T getOrNull(String propertyName, Function<String, T> mapper) {
+			return get(propertyName, mapper, null);
+		}
+
+		private <T> T get(String propertyName, Function<String, T> mapper, T defaultValue) {
+			return configurationParameters.get(prefix + propertyName).map(mapper).orElse(defaultValue);
 		}
 
 		private String getString(String propertyName) {
-			return get(propertyName, Function.identity());
+			return getOrNull(propertyName, Function.identity());
 		}
 
 		private Boolean getBoolean(String propertyName, boolean defaultValue) {
-			Boolean value = get(propertyName, Boolean::valueOf);
-			if (value == null) {
-				return defaultValue;
-			}
-			return value;
+			return get(propertyName, Boolean::valueOf, defaultValue);
 		}
 
 		private CommitDescriptor getCommitDescriptor(String propertyName) {
-			return get(propertyName, CommitDescriptor::parse);
+			return getOrNull(propertyName, CommitDescriptor::parse);
 		}
 
 		private List<String> getStringList(String propertyName) {
@@ -95,7 +95,7 @@ public class TestEngineOptionUtils {
 				}
 
 				return Arrays.asList(listAsString.split(","));
-			});
+			}, Collections.emptyList());
 		}
 	}
 }

--- a/impacted-test-engine/src/main/java/com/teamscale/test_impacted/engine/options/TestEngineOptionUtils.java
+++ b/impacted-test-engine/src/main/java/com/teamscale/test_impacted/engine/options/TestEngineOptionUtils.java
@@ -27,10 +27,10 @@ public class TestEngineOptionUtils {
 		return TestEngineOptions.builder()
 				.serverOptions(serverOptions)
 				.partition(propertyReader.getString("partition"))
-				.runImpacted(propertyReader.getBoolean("runImpacted"))
-				.runAllTests(propertyReader.getBoolean("runAllTests"))
-				.includeAddedTests(propertyReader.getBoolean("includeAddedTests"))
-				.includeFailedAndSkipped(propertyReader.getBoolean("includeFailedAndSkipped"))
+				.runImpacted(propertyReader.getBoolean("runImpacted", true))
+				.runAllTests(propertyReader.getBoolean("runAllTests", false))
+				.includeAddedTests(propertyReader.getBoolean("includeAddedTests", true))
+				.includeFailedAndSkipped(propertyReader.getBoolean("includeFailedAndSkipped", true))
 				.endCommit(propertyReader.getCommitDescriptor("endCommit"))
 				.baseline(propertyReader.getString("baseline"))
 				.agentUrls(propertyReader.getStringList("agentsUrls"))
@@ -61,7 +61,7 @@ public class TestEngineOptionUtils {
 
 		private final ConfigurationParameters configurationParameters;
 
-		private String prefix;
+		private final String prefix;
 
 		private PrefixingPropertyReader(String prefix, ConfigurationParameters configurationParameters) {
 			this.prefix = prefix;
@@ -76,8 +76,12 @@ public class TestEngineOptionUtils {
 			return get(propertyName, Function.identity());
 		}
 
-		private Boolean getBoolean(String propertyName) {
-			return get(propertyName, Boolean::valueOf);
+		private Boolean getBoolean(String propertyName, boolean defaultValue) {
+			Boolean value = get(propertyName, Boolean::valueOf);
+			if (value == null) {
+				return defaultValue;
+			}
+			return value;
 		}
 
 		private CommitDescriptor getCommitDescriptor(String propertyName) {

--- a/impacted-test-engine/src/main/java/com/teamscale/test_impacted/engine/options/TestEngineOptions.java
+++ b/impacted-test-engine/src/main/java/com/teamscale/test_impacted/engine/options/TestEngineOptions.java
@@ -178,7 +178,9 @@ public class TestEngineOptions {
 
 		/** @see #reportDirectory */
 		public Builder reportDirectory(String reportDirectory) {
-			testEngineOptions.reportDirectory = new File(reportDirectory);
+			if (reportDirectory != null) {
+				testEngineOptions.reportDirectory = new File(reportDirectory);
+			}
 			return this;
 		}
 


### PR DESCRIPTION
use sane defaults in that case

Addresses issue [TS-29597](https://cqse.atlassian.net/browse/TS-29597)

- [x] Changes are tested adequately
- [x] Agent's README.md updated in case of user-visible changes
- [x] CHANGELOG.md updated
- [x] Present new features in [N&N](https://wiki.cqse.eu/pages/viewpage.action?pageId=689566)
- [x] [TGA Tutorial](https://docs.teamscale.com/tutorial/setting-up-tga-java) updated
- [x] [TIA Tutorial](https://docs.teamscale.com/tutorial/tia-java/) updated

Please respect the vote of the [Teamscale bot](https://demo.teamscale.com) or flag irrelevant findings as tolerated or false positives. If you feel that the Teamscale config needs adjustment, please state so in a comment and discuss this with your reviewer.

