### PR TITLE
change default phase of Maven TIA IT mojo to PACKAGE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ We use [semantic versioning](http://semver.org/):
 # next release
 
 - [feature] The agent logs a warning when multiple java agents are used and recommends registering the Teamscale JaCoCo Agent first.
+- [fix] Maven plugin for TIA: sometimes the agent was not attached to a Spring Boot application during integration tests
 
 # 24.0.1
 

--- a/teamscale-maven-plugin/src/main/java/com/teamscale/tia/maven/TiaIntegrationTestMojo.java
+++ b/teamscale-maven-plugin/src/main/java/com/teamscale/tia/maven/TiaIntegrationTestMojo.java
@@ -8,7 +8,7 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 /**
  * Instruments the Failsafe integration tests and uploads testwise coverage to Teamscale.
  */
-@Mojo(name = "prepare-tia-integration-test", defaultPhase = LifecyclePhase.PRE_INTEGRATION_TEST,
+@Mojo(name = "prepare-tia-integration-test", defaultPhase = LifecyclePhase.PACKAGE,
 		requiresDependencyResolution = ResolutionScope.RUNTIME, threadSafe = true)
 public class TiaIntegrationTestMojo extends TiaMojoBase {
 


### PR DESCRIPTION
was: pre-instrumentation-tests, but the Spring Boot plugin also starts
the application under test in the same phase. Ordering of goals within
phases is unfortunately dependant on the order of the plugins in the POM
which we can't easily enforce to be correct. So we move our goal earlier
in the lifecycle to avoid potential incorrect orderings

Addresses issue https://cqse.atlassian.net/browse/TS-30654

- [x] Changes are tested adequately
- [x] Agent's README.md updated in case of user-visible changes
- [x] CHANGELOG.md updated
- [x] Present new features in [N&N](https://wiki.cqse.eu/pages/viewpage.action?pageId=689566)
- [x] [TGA Tutorial](https://docs.teamscale.com/tutorial/setting-up-tga-java) updated
- [x] [TIA Tutorial](https://docs.teamscale.com/tutorial/tia-java/) updated

Please respect the vote of the [Teamscale bot](https://demo.teamscale.com) or flag irrelevant findings as tolerated or false positives. If you feel that the Teamscale config needs adjustment, please state so in a comment and discuss this with your reviewer.

