### PR TITLE
TS-31797 teamscale-jacoco-agent gradle plugin fails with TaskDependencyResolveException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ We use [semantic versioning](http://semver.org/):
 - PATCH version when you make backwards compatible bug fixes.
 
 # Next Release
+- [fix] _teamscale-gradle-plugin_: Property 'outputLocation' is declared as an output property of Report xml (type TaskGeneratedSingleFileReport) but does not have a task associated with it.
 
 # 27.0.0
 

--- a/teamscale-gradle-plugin/src/main/kotlin/com/teamscale/Report.kt
+++ b/teamscale-gradle-plugin/src/main/kotlin/com/teamscale/Report.kt
@@ -4,9 +4,7 @@ import com.teamscale.client.EReportFormat
 import org.gradle.api.file.FileCollection
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.InputFiles
-import org.gradle.api.tasks.PathSensitive
-import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.Internal
 
 /**
  * Report holder used to describe an already configured report
@@ -21,9 +19,14 @@ data class Report(
     @Input
     val format: EReportFormat,
 
-    /** The report files. */
-    @InputFiles
-    @PathSensitive(PathSensitivity.RELATIVE)
+    /**
+     * The report files.
+     *
+     * Gradle currently fails to pick up the producer tasks of nested provider properties resulting in TS-31797
+     * (see https://github.com/gradle/gradle/issues/6619).
+     * As a workaround we use @Internal here and explicitly unwrap the reportFiles in TeamscaleUploadTask.getReportFiles.
+     */
+    @Internal
     val reportFiles: FileCollection,
 
     /** The partition to upload the report to. */

--- a/teamscale-gradle-plugin/src/main/kotlin/com/teamscale/TeamscaleUploadTask.kt
+++ b/teamscale-gradle-plugin/src/main/kotlin/com/teamscale/TeamscaleUploadTask.kt
@@ -23,6 +23,7 @@ abstract class TeamscaleUploadTask : DefaultTask() {
 
     /** The commit for which the reports should be uploaded. */
     @get:Input
+    @get:Optional
     val commitDescriptor
         get() = extension.commit.getOrResolveCommitDescriptor(project).first
 
@@ -31,6 +32,7 @@ abstract class TeamscaleUploadTask : DefaultTask() {
      * If set it is preferred over commitDescriptor.
      */
     @get:Input
+    @get:Optional
     val revision
         get() = extension.commit.getOrResolveCommitDescriptor(project).second
 

--- a/teamscale-gradle-plugin/src/main/kotlin/com/teamscale/TeamscaleUploadTask.kt
+++ b/teamscale-gradle-plugin/src/main/kotlin/com/teamscale/TeamscaleUploadTask.kt
@@ -40,6 +40,7 @@ abstract class TeamscaleUploadTask : DefaultTask() {
     @get:Nested
     abstract val reports: SetProperty<Report>
 
+    /** The report files. See Report.reportFiles for details. */
     @get:Input
     val reportFiles
         get() = reports.get().map { it.reportFiles }

--- a/teamscale-gradle-plugin/src/main/kotlin/com/teamscale/TeamscaleUploadTask.kt
+++ b/teamscale-gradle-plugin/src/main/kotlin/com/teamscale/TeamscaleUploadTask.kt
@@ -5,10 +5,7 @@ import com.teamscale.config.extension.TeamscalePluginExtension
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.provider.SetProperty
-import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.Internal
-import org.gradle.api.tasks.Nested
-import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.*
 import java.net.ConnectException
 import java.net.SocketTimeoutException
 
@@ -40,6 +37,10 @@ abstract class TeamscaleUploadTask : DefaultTask() {
     /** The list of reports to be uploaded. */
     @get:Nested
     abstract val reports: SetProperty<Report>
+
+    @get:Input
+    val reportFiles
+        get() = reports.get().map { it.reportFiles }
 
     @Input
     var ignoreFailures: Boolean = false

--- a/teamscale-gradle-plugin/src/main/kotlin/com/teamscale/config/JUnitReportConfiguration.kt
+++ b/teamscale-gradle-plugin/src/main/kotlin/com/teamscale/config/JUnitReportConfiguration.kt
@@ -16,7 +16,7 @@ open class JUnitReportConfiguration(project: Project, task: Test) :
 
     /** Allows to set the destination as a string, which is resolved as File internally. */
     fun setDestination(destination: String) {
-        this.destination.set(project.objects.directoryProperty().fileValue(File(destination)))
+        this.destination.set(project.objects.directoryProperty().fileValue(project.file(destination)))
     }
 
     override fun getReportFiles(): FileCollection {


### PR DESCRIPTION
Addresses issue [TS-31797](https://cqse.atlassian.net/browse/TS-31797)

- [ ] Changes are tested adequately
- [x] Agent's README.md updated in case of user-visible changes
- [x] CHANGELOG.md updated
- [ ] Present new features in [N&N](https://wiki.cqse.eu/pages/viewpage.action?pageId=689566)
- [ ] [TGA Tutorial](https://docs.teamscale.com/tutorial/setting-up-tga-java) updated
- [ ] [TIA Tutorial](https://docs.teamscale.com/tutorial/tia-java/) updated

Please respect the vote of the [Teamscale bot](https://demo.teamscale.com) or flag irrelevant findings as tolerated or false positives. If you feel that the Teamscale config needs adjustment, please state so in a comment and discuss this with your reviewer.

