### PR TITLE
TS-30752 Handle testwise coverage reports with partial coverage correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ We use [semantic versioning](http://semver.org/):
 - PATCH version when you make backwards compatible bug fixes.
 
 # Next Release
+- [fix] _teamscale-gradle-plugin_, _teamscale-maven-plugin_, _teamscale-jacoco-agent_: Tooling did not provide a way to set the partial flag
 
 # 29.0.0
 - [fix] Fixed the prefix extraction pattern and the partition pattern for Artifactory in the agent's documentation

--- a/agent/README.md
+++ b/agent/README.md
@@ -323,8 +323,10 @@ The agent's REST API has the following endpoints:
     If not given, the time since the last uploaded testwise coverage report is used (i.e. the last time you
     ran the TIA).
 
-- `[POST] /testrun/end` If you configured a connection to Teamscale via the `teamscale-` options and enabled
-  `teamscale-testwise-upload`, this will upload a testwise coverage report to Teamscale.
+- `[POST] /testrun/end?partial=true` If you configured a connection to Teamscale via the `teamscale-` options and enabled
+  `tia-mode=teamscale-upload`, this will upload a testwise coverage report to Teamscale. `partial` describes whether the 
+  recorded tests represent a subset of all tests i.e. only impacted tests were executed. This tells Teamscale to keep 
+- tests even if they are not present in the latest report. Defaults to `false`.
 - `[POST] /test/start/{uniformPath}` Signals to the agent that the test with the given uniformPath is about to start.
 - `[POST] /test/end/{uniformPath}` Signals to the agent that the test with the given uniformPath has just finished.
   The body of the request may optionally contain the test execution result in json format:

--- a/agent/src/main/java/com/teamscale/jacoco/agent/testimpact/TestEventHandlerStrategyBase.java
+++ b/agent/src/main/java/com/teamscale/jacoco/agent/testimpact/TestEventHandlerStrategyBase.java
@@ -133,7 +133,7 @@ public abstract class TestEventHandlerStrategyBase {
 	 * Signals that the test run has ended. Strategies that support this can upload a report via the {@link
 	 * #teamscaleClient} here.
 	 */
-	public void testRunEnd() throws IOException, CoverageGenerationException {
+	public void testRunEnd(boolean partial) throws IOException, CoverageGenerationException {
 		throw new UnsupportedOperationException("You configured the agent in a mode that does not support uploading " +
 				"reports to Teamscale. Please configure 'tia-mode=teamscale-upload' or simply don't call" +
 				"POST /testrun/end.");

--- a/agent/src/main/java/com/teamscale/jacoco/agent/testimpact/TestwiseCoverageAgent.java
+++ b/agent/src/main/java/com/teamscale/jacoco/agent/testimpact/TestwiseCoverageAgent.java
@@ -125,7 +125,8 @@ public class TestwiseCoverageAgent extends AgentBase {
 
 	private String handleTestRunEnd(Request request,
 									Response response) throws IOException, CoverageGenerationException {
-		testEventHandler.testRunEnd();
+		boolean partial = Boolean.parseBoolean(request.queryParamOrDefault("partial", "false"));
+		testEventHandler.testRunEnd(partial);
 		response.status(SC_NO_CONTENT);
 		return "";
 	}

--- a/agent/src/test/java/com/teamscale/jacoco/agent/testimpact/CoverageToTeamscaleStrategyTest.java
+++ b/agent/src/test/java/com/teamscale/jacoco/agent/testimpact/CoverageToTeamscaleStrategyTest.java
@@ -65,7 +65,7 @@ public class CoverageToTeamscaleStrategyTest {
 		strategy.testRunEnd();
 
 		verify(client).uploadReport(eq(EReportFormat.TESTWISE_COVERAGE),
-				matches("\\Q{\"tests\":[{\"duration\":\\E[^,]*\\Q,\"paths\":[{\"files\":[{\"coveredLines\":\"1-4\",\"fileName\":\"Main.java\"}],\"path\":\"src/main/java\"}],\"result\":\"PASSED\",\"sourcePath\":\"mytest\",\"uniformPath\":\"mytest\"}]}\\E"),
+				matches("\\Q{\"partial\":true,\"tests\":[{\"duration\":\\E[^,]*\\Q,\"paths\":[{\"files\":[{\"coveredLines\":\"1-4\",\"fileName\":\"Main.java\"}],\"path\":\"src/main/java\"}],\"result\":\"PASSED\",\"sourcePath\":\"mytest\",\"uniformPath\":\"mytest\"}]}\\E"),
 				any(), any(), any(), any());
 	}
 
@@ -94,7 +94,7 @@ public class CoverageToTeamscaleStrategyTest {
 		strategy.testRunEnd();
 
 		verify(client).uploadReport(eq(EReportFormat.TESTWISE_COVERAGE),
-				matches("\\Q{\"tests\":[{\"content\":\"content\",\"duration\":\\E[^,]*\\Q,\"paths\":[{\"files\":[{\"coveredLines\":\"1-4\",\"fileName\":\"Main.java\"}],\"path\":\"src/main/java\"}],\"result\":\"PASSED\",\"sourcePath\":\"mytest\",\"uniformPath\":\"mytest\"}]}\\E"),
+				matches("\\Q{\"partial\":true,\"tests\":[{\"content\":\"content\",\"duration\":\\E[^,]*\\Q,\"paths\":[{\"files\":[{\"coveredLines\":\"1-4\",\"fileName\":\"Main.java\"}],\"path\":\"src/main/java\"}],\"result\":\"PASSED\",\"sourcePath\":\"mytest\",\"uniformPath\":\"mytest\"}]}\\E"),
 				any(), any(), any(), any());
 	}
 

--- a/agent/src/test/java/com/teamscale/jacoco/agent/testimpact/CoverageToTeamscaleStrategyTest.java
+++ b/agent/src/test/java/com/teamscale/jacoco/agent/testimpact/CoverageToTeamscaleStrategyTest.java
@@ -62,10 +62,10 @@ public class CoverageToTeamscaleStrategyTest {
 		// we skip testRunStart and don't provide any available tests
 		strategy.testStart("mytest");
 		strategy.testEnd("mytest", new TestExecution("mytest", 0L, ETestExecutionResult.PASSED));
-		strategy.testRunEnd();
+		strategy.testRunEnd(false);
 
 		verify(client).uploadReport(eq(EReportFormat.TESTWISE_COVERAGE),
-				matches("\\Q{\"partial\":true,\"tests\":[{\"duration\":\\E[^,]*\\Q,\"paths\":[{\"files\":[{\"coveredLines\":\"1-4\",\"fileName\":\"Main.java\"}],\"path\":\"src/main/java\"}],\"result\":\"PASSED\",\"sourcePath\":\"mytest\",\"uniformPath\":\"mytest\"}]}\\E"),
+				matches("\\Q{\"partial\":false,\"tests\":[{\"duration\":\\E[^,]*\\Q,\"paths\":[{\"files\":[{\"coveredLines\":\"1-4\",\"fileName\":\"Main.java\"}],\"path\":\"src/main/java\"}],\"result\":\"PASSED\",\"sourcePath\":\"mytest\",\"uniformPath\":\"mytest\"}]}\\E"),
 				any(), any(), any(), any());
 	}
 
@@ -91,7 +91,7 @@ public class CoverageToTeamscaleStrategyTest {
 				null);
 		strategy.testStart("mytest");
 		strategy.testEnd("mytest", new TestExecution("mytest", 0L, ETestExecutionResult.PASSED));
-		strategy.testRunEnd();
+		strategy.testRunEnd(true);
 
 		verify(client).uploadReport(eq(EReportFormat.TESTWISE_COVERAGE),
 				matches("\\Q{\"partial\":true,\"tests\":[{\"content\":\"content\",\"duration\":\\E[^,]*\\Q,\"paths\":[{\"files\":[{\"coveredLines\":\"1-4\",\"fileName\":\"Main.java\"}],\"path\":\"src/main/java\"}],\"result\":\"PASSED\",\"sourcePath\":\"mytest\",\"uniformPath\":\"mytest\"}]}\\E"),

--- a/agent/src/test/java/com/teamscale/jacoco/agent/testimpact/TestwiseCoverageAgentTest.java
+++ b/agent/src/test/java/com/teamscale/jacoco/agent/testimpact/TestwiseCoverageAgentTest.java
@@ -93,7 +93,7 @@ public class TestwiseCoverageAgentTest {
 
 		testRun.endTestRun();
 		verify(client).uploadReport(eq(EReportFormat.TESTWISE_COVERAGE),
-				matches("\\Q{\"tests\":[{\"content\":\"content\",\"paths\":[],\"sourcePath\":\"test1\",\"uniformPath\":\"test1\"},{\"content\":\"content\",\"duration\":\\E[^,]*\\Q,\"message\":\"message\",\"paths\":[{\"files\":[{\"coveredLines\":\"1-4\",\"fileName\":\"Main.java\"}],\"path\":\"src/main/java\"}],\"result\":\"PASSED\",\"sourcePath\":\"test2\",\"uniformPath\":\"test2\"}]}\\E"),
+				matches("\\Q{\"partial\":true,\"tests\":[{\"content\":\"content\",\"paths\":[],\"sourcePath\":\"test1\",\"uniformPath\":\"test1\"},{\"content\":\"content\",\"duration\":\\E[^,]*\\Q,\"message\":\"message\",\"paths\":[{\"files\":[{\"coveredLines\":\"1-4\",\"fileName\":\"Main.java\"}],\"path\":\"src/main/java\"}],\"result\":\"PASSED\",\"sourcePath\":\"test2\",\"uniformPath\":\"test2\"}]}\\E"),
 				any(), any(), any(), any());
 	}
 

--- a/agent/src/test/java/com/teamscale/jacoco/agent/testimpact/TestwiseCoverageAgentTest.java
+++ b/agent/src/test/java/com/teamscale/jacoco/agent/testimpact/TestwiseCoverageAgentTest.java
@@ -91,7 +91,7 @@ public class TestwiseCoverageAgentTest {
 		RunningTest runningTest = testRun.startTest(test.testName);
 		runningTest.endTest(new TestRun.TestResultWithMessage(ETestExecutionResult.PASSED, "message"));
 
-		testRun.endTestRun();
+		testRun.endTestRun(true);
 		verify(client).uploadReport(eq(EReportFormat.TESTWISE_COVERAGE),
 				matches("\\Q{\"partial\":true,\"tests\":[{\"content\":\"content\",\"paths\":[],\"sourcePath\":\"test1\",\"uniformPath\":\"test1\"},{\"content\":\"content\",\"duration\":\\E[^,]*\\Q,\"message\":\"message\",\"paths\":[{\"files\":[{\"coveredLines\":\"1-4\",\"fileName\":\"Main.java\"}],\"path\":\"src/main/java\"}],\"result\":\"PASSED\",\"sourcePath\":\"test2\",\"uniformPath\":\"test2\"}]}\\E"),
 				any(), any(), any(), any());

--- a/impacted-test-engine/src/main/java/com/teamscale/test_impacted/engine/executor/ImpactedTestsExecutor.java
+++ b/impacted-test-engine/src/main/java/com/teamscale/test_impacted/engine/executor/ImpactedTestsExecutor.java
@@ -23,7 +23,7 @@ public class ImpactedTestsExecutor extends TestwiseCoverageCollectingTestExecuto
 
 	public ImpactedTestsExecutor(List<ITestwiseCoverageAgentApi> testwiseCoverageAgentApis,
 								 ImpactedTestsProvider impactedTestsProvider) {
-		super(testwiseCoverageAgentApis);
+		super(testwiseCoverageAgentApis, !impactedTestsProvider.isIncludeNonImpacted());
 		this.impactedTestsProvider = impactedTestsProvider;
 	}
 

--- a/impacted-test-engine/src/main/java/com/teamscale/test_impacted/engine/executor/ImpactedTestsProvider.java
+++ b/impacted-test-engine/src/main/java/com/teamscale/test_impacted/engine/executor/ImpactedTestsProvider.java
@@ -50,6 +50,11 @@ public class ImpactedTestsProvider {
 		this.includeFailedAndSkipped = includeFailedAndSkipped;
 	}
 
+	/** @see #includeNonImpacted  */
+	public boolean isIncludeNonImpacted() {
+		return includeNonImpacted;
+	}
+
 	/** Queries Teamscale for impacted tests. */
 	public List<PrioritizableTestCluster> getImpactedTestsFromTeamscale(
 			List<ClusteredTestDetails> availableTestDetails) {

--- a/impacted-test-engine/src/main/java/com/teamscale/test_impacted/engine/executor/TestwiseCoverageCollectingExecutionListener.java
+++ b/impacted-test-engine/src/main/java/com/teamscale/test_impacted/engine/executor/TestwiseCoverageCollectingExecutionListener.java
@@ -46,15 +46,17 @@ class TestwiseCoverageCollectingExecutionListener implements EngineExecutionList
 	private final ITestDescriptorResolver testDescriptorResolver;
 
 	private final EngineExecutionListener delegateEngineExecutionListener;
+	private final boolean partial;
 
 	private final Map<UniqueId, TestExecutionResult> testResultCache = new HashMap<>();
 
 	TestwiseCoverageCollectingExecutionListener(List<ITestwiseCoverageAgentApi> testwiseCoverageAgentApis,
 												ITestDescriptorResolver testDescriptorResolver,
-												EngineExecutionListener engineExecutionListener) {
+												EngineExecutionListener engineExecutionListener, boolean partial) {
 		this.testwiseCoverageAgentApis = testwiseCoverageAgentApis;
 		this.testDescriptorResolver = testDescriptorResolver;
 		this.delegateEngineExecutionListener = engineExecutionListener;
+		this.partial = partial;
 	}
 
 	@Override
@@ -187,7 +189,7 @@ class TestwiseCoverageCollectingExecutionListener implements EngineExecutionList
 	private void endTestRun() {
 		try {
 			for (ITestwiseCoverageAgentApi apiService : testwiseCoverageAgentApis) {
-				apiService.testRunFinished().execute();
+				apiService.testRunFinished(partial).execute();
 			}
 		} catch (IOException e) {
 			LOGGER.error(e, () -> "Error contacting test wise coverage agent.");

--- a/impacted-test-engine/src/main/java/com/teamscale/test_impacted/engine/executor/TestwiseCoverageCollectingTestExecutor.java
+++ b/impacted-test-engine/src/main/java/com/teamscale/test_impacted/engine/executor/TestwiseCoverageCollectingTestExecutor.java
@@ -12,9 +12,11 @@ import java.util.List;
 public class TestwiseCoverageCollectingTestExecutor implements ITestExecutor {
 
 	private final List<ITestwiseCoverageAgentApi> testwiseCoverageAgentApis;
+	private final boolean partial;
 
-	public TestwiseCoverageCollectingTestExecutor(List<ITestwiseCoverageAgentApi> testwiseCoverageAgentApis) {
+	public TestwiseCoverageCollectingTestExecutor(List<ITestwiseCoverageAgentApi> testwiseCoverageAgentApis, boolean partial) {
 		this.testwiseCoverageAgentApis = testwiseCoverageAgentApis;
+		this.partial = partial;
 	}
 
 	@Override
@@ -23,7 +25,7 @@ public class TestwiseCoverageCollectingTestExecutor implements ITestExecutor {
 				.getTestDescriptorResolver(testExecutorRequest.testEngine);
 		TestwiseCoverageCollectingExecutionListener executionListener =
 				new TestwiseCoverageCollectingExecutionListener(testwiseCoverageAgentApis, testDescriptorResolver,
-						testExecutorRequest.engineExecutionListener);
+						testExecutorRequest.engineExecutionListener, partial);
 
 		testExecutorRequest.testEngine.execute(new ExecutionRequest(testExecutorRequest.engineTestDescriptor,
 				executionListener, testExecutorRequest.configurationParameters));

--- a/impacted-test-engine/src/main/java/com/teamscale/test_impacted/engine/options/TestEngineOptions.java
+++ b/impacted-test-engine/src/main/java/com/teamscale/test_impacted/engine/options/TestEngineOptions.java
@@ -95,7 +95,7 @@ public class TestEngineOptions {
 
 	private ITestExecutor createTestExecutor() {
 		if (!isRunImpacted()) {
-			return new TestwiseCoverageCollectingTestExecutor(testwiseCoverageAgentApis);
+			return new TestwiseCoverageCollectingTestExecutor(testwiseCoverageAgentApis, false);
 		}
 
 		TeamscaleClient client = new TeamscaleClient(serverOptions.getUrl(), serverOptions.getUserName(),

--- a/impacted-test-engine/src/test/java/com/teamscale/test_impacted/engine/InternalImpactedTestEngineTest.java
+++ b/impacted-test-engine/src/test/java/com/teamscale/test_impacted/engine/InternalImpactedTestEngineTest.java
@@ -76,7 +76,7 @@ class InternalImpactedTestEngineTest {
 		when(testwiseCoverageAgentApi.testStarted(anyString())).thenReturn(mock(Call.class));
 		when(testwiseCoverageAgentApi.testFinished(anyString())).thenReturn(mock(Call.class));
 		when(testwiseCoverageAgentApi.testFinished(anyString(), any())).thenReturn(mock(Call.class));
-		when(testwiseCoverageAgentApi.testRunFinished()).thenReturn(mock(Call.class));
+		when(testwiseCoverageAgentApi.testRunFinished(any())).thenReturn(mock(Call.class));
 	}
 
 	@SafeVarargs

--- a/impacted-test-engine/src/test/java/com/teamscale/test_impacted/engine/executor/TestwiseCoverageCollectingExecutionListenerTest.java
+++ b/impacted-test-engine/src/test/java/com/teamscale/test_impacted/engine/executor/TestwiseCoverageCollectingExecutionListenerTest.java
@@ -38,7 +38,7 @@ class TestwiseCoverageCollectingExecutionListenerTest {
 	private final EngineExecutionListener executionListenerMock = mock(EngineExecutionListener.class);
 
 	private final TestwiseCoverageCollectingExecutionListener executionListener = new TestwiseCoverageCollectingExecutionListener(
-			singletonList(mockApi), resolver, executionListenerMock);
+			singletonList(mockApi), resolver, executionListenerMock, true);
 
 	private final UniqueId rootId = UniqueId.forEngine("dummy");
 
@@ -48,7 +48,7 @@ class TestwiseCoverageCollectingExecutionListenerTest {
 		when(mockApi.testStarted(anyString())).thenReturn(mock(Call.class));
 		when(mockApi.testFinished(anyString())).thenReturn(mock(Call.class));
 		when(mockApi.testFinished(anyString(), any())).thenReturn(mock(Call.class));
-		when(mockApi.testRunFinished()).thenReturn(mock(Call.class));
+		when(mockApi.testRunFinished(any())).thenReturn(mock(Call.class));
 	}
 
 	@SuppressWarnings("unchecked")
@@ -102,7 +102,7 @@ class TestwiseCoverageCollectingExecutionListenerTest {
 		verify(executionListenerMock).executionFinished(testClass, successful());
 		executionListener.executionFinished(testRoot, successful());
 		verify(executionListenerMock).executionFinished(testRoot, successful());
-		verify(mockApi).testRunFinished();
+		verify(mockApi).testRunFinished(true);
 
 		verifyNoMoreInteractions(mockApi);
 		verifyNoMoreInteractions(executionListenerMock);

--- a/report-generator/src/main/java/com/teamscale/report/testwise/model/TestwiseCoverageReport.java
+++ b/report-generator/src/main/java/com/teamscale/report/testwise/model/TestwiseCoverageReport.java
@@ -6,6 +6,13 @@ import java.util.List;
 /** Container for coverage produced by multiple tests. */
 public class TestwiseCoverageReport {
 
+	/**
+	 * If set to `true` the set of tests contained in the report don't represent the full set of tests within a
+	 * partition. These tests are added or updated in Teamscale, but no tests or executable units that are missing in
+	 * the report will be deleted.
+	 */
+	public final boolean partial = true;
+
 	/** The tests contained in the report. */
 	public final List<TestInfo> tests = new ArrayList<>();
 

--- a/report-generator/src/main/java/com/teamscale/report/testwise/model/TestwiseCoverageReport.java
+++ b/report-generator/src/main/java/com/teamscale/report/testwise/model/TestwiseCoverageReport.java
@@ -11,9 +11,12 @@ public class TestwiseCoverageReport {
 	 * partition. These tests are added or updated in Teamscale, but no tests or executable units that are missing in
 	 * the report will be deleted.
 	 */
-	public final boolean partial = true;
+	public final boolean partial;
 
 	/** The tests contained in the report. */
 	public final List<TestInfo> tests = new ArrayList<>();
 
+	public TestwiseCoverageReport(boolean partial) {
+		this.partial = partial;
+	}
 }

--- a/report-generator/src/main/java/com/teamscale/report/testwise/model/builder/TestwiseCoverageReportBuilder.java
+++ b/report-generator/src/main/java/com/teamscale/report/testwise/model/builder/TestwiseCoverageReportBuilder.java
@@ -25,7 +25,8 @@ public class TestwiseCoverageReportBuilder {
 	public static TestwiseCoverageReport createFrom(
 			Collection<? extends TestDetails> testDetailsList,
 			Collection<TestCoverageBuilder> testCoverage,
-			Collection<TestExecution> testExecutions
+			Collection<TestExecution> testExecutions,
+			boolean partial
 	) {
 		TestwiseCoverageReportBuilder report = new TestwiseCoverageReportBuilder();
 		for (TestDetails testDetails : testDetailsList) {
@@ -47,7 +48,7 @@ public class TestwiseCoverageReportBuilder {
 			}
 			container.setExecution(testExecution);
 		}
-		return report.build();
+		return report.build(partial);
 	}
 
 	private static TestInfoBuilder resolveUniformPath(TestwiseCoverageReportBuilder report, String uniformPath) {
@@ -70,8 +71,8 @@ public class TestwiseCoverageReportBuilder {
 		return uniformPath.replaceFirst("(.*\\))\\[.*]", "$1");
 	}
 
-	private TestwiseCoverageReport build() {
-		TestwiseCoverageReport report = new TestwiseCoverageReport();
+	private TestwiseCoverageReport build(boolean partial) {
+		TestwiseCoverageReport report = new TestwiseCoverageReport(partial);
 		List<TestInfoBuilder> testInfoBuilders = new ArrayList<>(tests.values());
 		testInfoBuilders.sort(Comparator.comparing(TestInfoBuilder::getUniformPath));
 		for (TestInfoBuilder testInfoBuilder : testInfoBuilders) {

--- a/report-generator/src/test/java/com/teamscale/report/testwise/jacoco/JaCoCoTestwiseReportGeneratorTest.java
+++ b/report-generator/src/test/java/com/teamscale/report/testwise/jacoco/JaCoCoTestwiseReportGeneratorTest.java
@@ -68,7 +68,7 @@ public class JaCoCoTestwiseReportGeneratorTest extends TestDataBase {
 			testExecutions.add(new TestExecution(test.getUniformPath(), test.getUniformPath().length(),
 					ETestExecutionResult.PASSED));
 		}
-		return TestwiseCoverageReportBuilder.createFrom(testDetails, testwiseCoverage.getTests(), testExecutions);
+		return TestwiseCoverageReportBuilder.createFrom(testDetails, testwiseCoverage.getTests(), testExecutions, true);
 	}
 
 }

--- a/report-generator/test-data/com.teamscale.report.testwise.jacoco/jacoco/cqddl/report.json.expected
+++ b/report-generator/test-data/com.teamscale.report.testwise.jacoco/jacoco/cqddl/report.json.expected
@@ -1,4 +1,5 @@
 {
+  "partial": true,
   "tests": [
     {
       "uniformPath": "[engine:junit-vintage]/[runner:org.conqat.lib.cqddl.CQDDLTest]/[test:testDirectObjectInsertion(org.conqat.lib.cqddl.CQDDLTest)]",

--- a/report-generator/test-data/com.teamscale.report.testwise.jacoco/jacoco/default-package/report.json.expected
+++ b/report-generator/test-data/com.teamscale.report.testwise.jacoco/jacoco/default-package/report.json.expected
@@ -1,4 +1,5 @@
 {
+  "partial": true,
 	"tests": [
 		{
 			"duration": 0.026,

--- a/report-generator/test-data/com.teamscale.report.testwise.jacoco/jacoco/sample/report.json.expected
+++ b/report-generator/test-data/com.teamscale.report.testwise.jacoco/jacoco/sample/report.json.expected
@@ -1,4 +1,5 @@
 {
+  "partial": true,
   "tests": [
     {
       "uniformPath": "com/example/project/JUnit4Test/testMul",

--- a/system-tests/tia-client-test/src/main/java/testframework/CustomTestFramework.java
+++ b/system-tests/tia-client-test/src/main/java/testframework/CustomTestFramework.java
@@ -58,7 +58,7 @@ public class CustomTestFramework {
 			}
 		}
 
-		testRun.endTestRun();
+		testRun.endTestRun(true);
 	}
 
 }

--- a/system-tests/tia-maven/src/test/java/com/teamscale/tia/TiaMavenSystemTest.java
+++ b/system-tests/tia-maven/src/test/java/com/teamscale/tia/TiaMavenSystemTest.java
@@ -41,6 +41,7 @@ public class TiaMavenSystemTest {
 
 		TestwiseCoverageReport unitTestReport = teamscaleMockServer.parseUploadedTestwiseCoverageReport(0);
 		assertThat(unitTestReport.tests).hasSize(2);
+		assertThat(unitTestReport.partial).isTrue();
 		assertAll(() -> {
 			assertThat(unitTestReport.tests).extracting(test -> test.uniformPath)
 					.containsExactlyInAnyOrder("bar/UnitTest/utBla()", "bar/UnitTest/utFoo()");

--- a/teamscale-gradle-plugin/src/main/kotlin/com/teamscale/Report.kt
+++ b/teamscale-gradle-plugin/src/main/kotlin/com/teamscale/Report.kt
@@ -35,5 +35,9 @@ data class Report(
 
     /** The commit message shown in Teamscale for the upload. */
     @Input
-    var message: String
+    var message: String,
+
+    /** Whether the report only contains partial data (subset of tests). Only relevant for TESTWISE_COVERAGE. */
+    @Input
+    var partial: Boolean = false
 )

--- a/teamscale-gradle-plugin/src/main/kotlin/com/teamscale/TestImpacted.kt
+++ b/teamscale-gradle-plugin/src/main/kotlin/com/teamscale/TestImpacted.kt
@@ -2,9 +2,6 @@ package com.teamscale
 
 import com.teamscale.config.extension.TeamscalePluginExtension
 import com.teamscale.config.extension.TeamscaleTestImpactedTaskExtension
-import groovy.lang.Closure
-import org.gradle.api.Action
-import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.artifacts.ProjectDependency
 import org.gradle.api.file.FileCollection
@@ -13,9 +10,7 @@ import org.gradle.api.provider.Property
 import org.gradle.api.tasks.*
 import org.gradle.api.tasks.options.Option
 import org.gradle.api.tasks.testing.Test
-import org.gradle.api.tasks.testing.junit.JUnitOptions
 import org.gradle.api.tasks.testing.junitplatform.JUnitPlatformOptions
-import org.gradle.api.tasks.testing.testng.TestNGOptions
 import javax.inject.Inject
 
 /** Task which runs the impacted tests. */
@@ -147,7 +142,7 @@ open class TestImpacted @Inject constructor(objects: ObjectFactory) : Test() {
             }
 
             val reportConfig = taskExtension.report
-            val report = reportConfig.getReport()
+            val report = reportConfig.getReport().copy(partial = runImpacted && !runAllTests)
 
             reportTask.addTestArtifactsDirs(report, reportOutputDir)
 

--- a/teamscale-gradle-plugin/src/main/kotlin/com/teamscale/TestwiseCoverageReportTask.kt
+++ b/teamscale-gradle-plugin/src/main/kotlin/com/teamscale/TestwiseCoverageReportTask.kt
@@ -119,7 +119,7 @@ open class TestwiseCoverageReportTask : DefaultTask() {
 
         logger.info("Merging report with ${testDetails.size} Details/${testwiseCoverage.tests.size} Coverage/${testExecutions.size} Results")
 
-        val report = TestwiseCoverageReportBuilder.createFrom(testDetails, testwiseCoverage.tests, testExecutions)
+        val report = TestwiseCoverageReportBuilder.createFrom(testDetails, testwiseCoverage.tests, testExecutions, reportConfig.partial)
         logger.info("Writing report to ${reportConfig.reportFiles}")
         ReportUtils.writeTestwiseCoverageReport(reportConfig.reportFiles.singleFile, report)
     }

--- a/teamscale-maven-plugin/build.gradle
+++ b/teamscale-maven-plugin/build.gradle
@@ -6,6 +6,7 @@ class MavenExec extends Exec {
 		def mavenExecutable = Os.isFamily(Os.FAMILY_WINDOWS) ? "mvnw.cmd" : "./mvnw"
 		setExecutable(mavenExecutable)
 		workingDir('.')
+		environment("AGENT_VERSION", project.version)
 		super.exec()
 	}
 }

--- a/teamscale-maven-plugin/build.gradle
+++ b/teamscale-maven-plugin/build.gradle
@@ -6,8 +6,9 @@ class MavenExec extends Exec {
 		def mavenExecutable = Os.isFamily(Os.FAMILY_WINDOWS) ? "mvnw.cmd" : "./mvnw"
 		setExecutable(mavenExecutable)
 		workingDir('.')
-		environment("AGENT_VERSION", project.version)
+		project.file('pom.xml').text = project.file('pom.xml').text.replaceAll("<teamscale.agent.version>[^<]+</teamscale.agent.version>", "<teamscale.agent.version>$project.version</teamscale.agent.version>")
 		super.exec()
+		project.file('pom.xml').text = project.file('pom.xml').text.replaceAll("<teamscale.agent.version>[^<]+</teamscale.agent.version>", "<teamscale.agent.version>29.0.0</teamscale.agent.version>")
 	}
 }
 

--- a/teamscale-maven-plugin/pom.xml
+++ b/teamscale-maven-plugin/pom.xml
@@ -54,7 +54,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <revision>1.0.0-SNAPSHOT</revision>
-        <teamscale.agent.version>23.1.1</teamscale.agent.version>
+        <teamscale.agent.version>${env.AGENT_VERSION}</teamscale.agent.version>
     </properties>
 
     <dependencies>

--- a/teamscale-maven-plugin/pom.xml
+++ b/teamscale-maven-plugin/pom.xml
@@ -54,7 +54,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <revision>1.0.0-SNAPSHOT</revision>
-        <teamscale.agent.version>${env.AGENT_VERSION}</teamscale.agent.version>
+        <teamscale.agent.version>29.0.0</teamscale.agent.version>
     </properties>
 
     <dependencies>

--- a/tia-client/src/main/java/com/teamscale/tia.client/CommandLineInterface.java
+++ b/tia-client/src/main/java/com/teamscale/tia.client/CommandLineInterface.java
@@ -81,7 +81,13 @@ public class CommandLineInterface {
 	}
 
 	private void endTestRun() throws Exception {
-		AgentCommunicationUtils.handleRequestError(api::testRunFinished,
+		boolean partial;
+		if (arguments.size() == 1) {
+			partial = Boolean.parseBoolean(arguments.remove(0));
+		} else {
+			partial = false;
+		}
+		AgentCommunicationUtils.handleRequestError(() -> api.testRunFinished(partial),
 				"Failed to create a coverage report and upload it to Teamscale. The coverage is most likely lost");
 	}
 

--- a/tia-client/src/main/java/com/teamscale/tia.client/ITestwiseCoverageAgentApi.java
+++ b/tia-client/src/main/java/com/teamscale/tia.client/ITestwiseCoverageAgentApi.java
@@ -66,9 +66,12 @@ public interface ITestwiseCoverageAgentApi {
 			@Body List<ClusteredTestDetails> availableTests
 	);
 
-	/** Test run finished. Generate test-wise coverage report and upload to Teamscale. */
+	/**
+	 * Test run finished. Generate test-wise coverage report and upload to Teamscale.
+	 * @param partial Whether the test recording only contains a subset of the available tests.
+	 */
 	@POST("testrun/end")
-	Call<ResponseBody> testRunFinished();
+	Call<ResponseBody> testRunFinished(@Query("partial") Boolean partial);
 
 	/**
 	 * Generates a {@link Retrofit} instance for this service, which uses basic auth to authenticate against the server

--- a/tia-client/src/main/java/com/teamscale/tia.client/TestRun.java
+++ b/tia-client/src/main/java/com/teamscale/tia.client/TestRun.java
@@ -5,7 +5,7 @@ import com.teamscale.report.testwise.model.ETestExecutionResult;
 /**
  * Use this class to report test start and end events and upload testwise coverage to Teamscale.
  * <p>
- * After having run all tests, call {@link #endTestRun()} to create a testwise coverage report and upload it to
+ * After having run all tests, call {@link #endTestRun(boolean)} to create a testwise coverage report and upload it to
  * Teamscale. This requires that you configured the agent to upload coverage to Teamscale
  * (`tia-mode=teamscale-upload`).
  */
@@ -62,8 +62,8 @@ public class TestRun {
 	 *                                         failure. The recorded coverage is likely lost. The caller should log this
 	 *                                         problem appropriately.
 	 */
-	public void endTestRun() throws AgentHttpRequestFailedException {
-		AgentCommunicationUtils.handleRequestError(api::testRunFinished,
+	public void endTestRun(boolean partial) throws AgentHttpRequestFailedException {
+		AgentCommunicationUtils.handleRequestError(() -> api.testRunFinished(partial),
 				"Failed to create a coverage report and upload it to Teamscale. The coverage is most likely lost");
 	}
 

--- a/tia-client/src/main/java/com/teamscale/tia.client/TestRunWithClusteredSuggestions.java
+++ b/tia-client/src/main/java/com/teamscale/tia.client/TestRunWithClusteredSuggestions.java
@@ -11,7 +11,7 @@ import java.util.List;
  * The caller of this class should retrieve the test clusters to execute from {@link #getPrioritizedClusters()}, run
  * them (in the given order if possible) and report test start and end events via {@link #startTest(String)} )}.
  * <p>
- * After having run all tests, call {@link #endTestRun()} to create a testwise coverage report and upload it to
+ * After having run all tests, call {@link #endTestRun(boolean)} to create a testwise coverage report and upload it to
  * Teamscale.
  */
 public class TestRunWithClusteredSuggestions extends TestRun {

--- a/tia-client/src/main/java/com/teamscale/tia.client/TestRunWithFlatSuggestions.java
+++ b/tia-client/src/main/java/com/teamscale/tia.client/TestRunWithFlatSuggestions.java
@@ -11,7 +11,7 @@ import java.util.List;
  * The caller of this class should retrieve the tests to execute from {@link #getPrioritizedTests()}, run them (in the
  * given order if possible) and report test start and end events via {@link #startTest(String)} )}.
  * <p>
- * After having run all tests, call {@link #endTestRun()} to create a testwise coverage report and upload it to
+ * After having run all tests, call {@link #endTestRun(boolean)} to create a testwise coverage report and upload it to
  * Teamscale.
  */
 public class TestRunWithFlatSuggestions extends TestRun {

--- a/tia-runlisteners/src/main/java/com/teamscale/tia/runlistener/RunListenerAgentBridge.java
+++ b/tia-runlisteners/src/main/java/com/teamscale/tia/runlistener/RunListenerAgentBridge.java
@@ -107,6 +107,6 @@ public class RunListenerAgentBridge {
 	 */
 	public void testRunFinished() {
 		logger.debug("Finished test run");
-		handleErrors(testRun::endTestRun, "Finishing the test run");
+		handleErrors(() -> testRun.endTestRun(false), "Finishing the test run");
 	}
 }


### PR DESCRIPTION
Addresses issue [TS-30752](https://cqse.atlassian.net/browse/TS-30752)

- [x] Changes are tested adequately
- [x] Agent's README.md updated in case of user-visible changes
- [x] CHANGELOG.md updated
- [ ] Present new features in [N&N](https://wiki.cqse.eu/pages/viewpage.action?pageId=689566)
- [ ] [TGA Tutorial](https://docs.teamscale.com/tutorial/setting-up-tga-java) updated
- [ ] [TIA Tutorial](https://docs.teamscale.com/tutorial/tia-java/) updated

Please respect the vote of the [Teamscale bot](https://demo.teamscale.com) or flag irrelevant findings as tolerated or false positives. If you feel that the Teamscale config needs adjustment, please state so in a comment and discuss this with your reviewer.

