### PR TITLE
TS-35396 Maven plugin: Use semicolon instead of comma to separate in/…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ We use [semantic versioning](http://semver.org/):
 # Next Release
 - [breaking] Replaced `teamscale-git-properties-jar` with `git-properties-jar`. Jars/Wars/Ears/Aars provided with this option will now also be searched recursively for git.properties files except you set `search-git-properties-recursively=false`.
 - [feature] support `full` mode of the Maven git-commit-id plugin.
+- [fix] Providing multiple include pattern in the maven plugin resulted in no coverage being collected
 
 # 30.1.1
 - [fix] _teamscale-gradle-plugin_: Warnings were logged during test execution (WARNING: JAXBContext implementation could not be found. WADL feature is disabled., WARNING: A class javax.activation.DataSource for a default provider)

--- a/teamscale-maven-plugin/src/main/java/com/teamscale/tia/maven/TiaMojoBase.java
+++ b/teamscale-maven-plugin/src/main/java/com/teamscale/tia/maven/TiaMojoBase.java
@@ -398,10 +398,10 @@ public abstract class TiaMojoBase extends AbstractMojo {
 				"\nlogging-config=" + loggingConfigPath +
 				"\nout=" + agentOutputDirectory.toAbsolutePath();
 		if (ArrayUtils.isNotEmpty(includes)) {
-			config += "\nincludes=" + String.join(",", includes);
+			config += "\nincludes=" + String.join(";", includes);
 		}
 		if (ArrayUtils.isNotEmpty(excludes)) {
-			config += "\nexcludes=" + String.join(",", excludes);
+			config += "\nexcludes=" + String.join(";", excludes);
 		}
 		return config;
 	}


### PR DESCRIPTION
…exclude files in the generated JaCoCo agent config

Addresses issue [TS-35396](https://cqse.atlassian.net/browse/TS-35396)

- [ ] Changes are tested adequately
- [x] Agent's README.md updated in case of user-visible changes
- [x] CHANGELOG.md updated
- [x] Present new features in [N&N](https://wiki.cqse.eu/pages/viewpage.action?pageId=689566)
- [x] [TGA Tutorial](https://docs.teamscale.com/tutorial/setting-up-tga-java) updated
- [x] [TIA Tutorial](https://docs.teamscale.com/tutorial/tia-java/) updated

Please respect the vote of the [Teamscale bot](https://demo.teamscale.com) or flag irrelevant findings as tolerated or false positives. If you feel that the Teamscale config needs adjustment, please state so in a comment and discuss this with your reviewer.

