### PR TITLE
TS-35849 Fix ambiguous test name extraction from cucumber

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ We use [semantic versioning](http://semver.org/):
 
 # Next Release
 - _impacted-test-engine_: Failed requests to Teamscale did result in unreadable error message
+- [fix] _teamscale-maven-plugin_: Same uniform path was extracted for Cucumber scenario outlines which do not have their parameters in the title
 
 # 32.2.0
 - [feature] _agent_: Previously unsuccessful coverage uploads are now automatically retried upon agent restart

--- a/system-tests/cucumber-maven-tia/maven-project/src/test/resources/hellocucumber/calculator.feature
+++ b/system-tests/cucumber-maven-tia/maven-project/src/test/resources/hellocucumber/calculator.feature
@@ -8,7 +8,7 @@ Feature: Calculator
     When I add 0 and 0
     Then the result should be 0
 
-  Scenario Outline: Add two numbers <num1> & <num2>
+  Scenario Outline: Add two numbers
     Given I have a calculator
     When I add <num1> and <num2>
     Then the result should be <total>

--- a/system-tests/cucumber-maven-tia/src/test/java/com/teamscale/tia/TiaMavenCucumberSystemTest.java
+++ b/system-tests/cucumber-maven-tia/src/test/java/com/teamscale/tia/TiaMavenCucumberSystemTest.java
@@ -28,8 +28,9 @@ public class TiaMavenCucumberSystemTest {
 	public void startFakeTeamscaleServer() throws Exception {
 		if (teamscaleMockServer == null) {
 			teamscaleMockServer = new TeamscaleMockServer(FAKE_TEAMSCALE_PORT, false,
-					"hellocucumber/RunCucumberTest/hellocucumber/calculator.feature/Add two numbers 0 & 0",
-					"hellocucumber/RunCucumberTest/hellocucumber/calculator.feature/Subtract two numbers 99 & 99");
+					"hellocucumber/RunCucumberTest/hellocucumber/calculator.feature/Add two numbers 0 & 0/Add two numbers 0 & 0",
+					"hellocucumber/RunCucumberTest/hellocucumber/calculator.feature/Add two numbers/Example #1.1",
+					"hellocucumber/RunCucumberTest/hellocucumber/calculator.feature/Add two numbers/Example #1.2");
 		}
 		teamscaleMockServer.uploadedReports.clear();
 	}
@@ -48,18 +49,24 @@ public class TiaMavenCucumberSystemTest {
 		assertThat(teamscaleMockServer.uploadedReports).hasSize(1);
 
 		TestwiseCoverageReport unitTestReport = teamscaleMockServer.parseUploadedTestwiseCoverageReport(0);
-		assertThat(unitTestReport.tests).hasSize(2);
+		assertThat(unitTestReport.tests).hasSize(3);
 		assertThat(unitTestReport.partial).isTrue();
 		assertAll(() -> {
 			assertThat(unitTestReport.tests).extracting(test -> test.uniformPath)
 					.containsExactlyInAnyOrder(
-							"hellocucumber/RunCucumberTest/hellocucumber/calculator.feature/Add two numbers 0 & 0",
-							"hellocucumber/RunCucumberTest/hellocucumber/calculator.feature/Subtract two numbers 99 & 99");
+							"hellocucumber/RunCucumberTest/hellocucumber/calculator.feature/Add two numbers 0 & 0/Add two numbers 0 & 0",
+							"hellocucumber/RunCucumberTest/hellocucumber/calculator.feature/Add two numbers/Example #1.1",
+							"hellocucumber/RunCucumberTest/hellocucumber/calculator.feature/Add two numbers/Example #1.2"
+					);
 			assertThat(unitTestReport.tests).extracting(test -> test.result)
-					.containsExactlyInAnyOrder(ETestExecutionResult.PASSED, ETestExecutionResult.PASSED);
+					.containsExactlyInAnyOrder(ETestExecutionResult.PASSED, ETestExecutionResult.PASSED,
+							ETestExecutionResult.PASSED);
 			assertThat(unitTestReport.tests).extracting(SystemTestUtils::getCoverageString)
-					.containsExactly("Calculator.java:3,5;StepDefinitions.java:12,24-25,29-30,39-40",
-							"Calculator.java:3,9;StepDefinitions.java:12,24-25,34-35,39-40");
+					.containsExactly(
+							"Calculator.java:3,5;StepDefinitions.java:12,24-25,29-30,39-40",
+							"Calculator.java:3,5;StepDefinitions.java:12,24-25,29-30,39-40",
+							"Calculator.java:3,5;StepDefinitions.java:12,24-25,29-30,39-40"
+					);
 		});
 	}
 


### PR DESCRIPTION
Addresses issue [TS-35849](https://cqse.atlassian.net/browse/TS-35849)

- [x] Changes are tested adequately
- [x] Agent's README.md updated in case of user-visible changes
- [x] CHANGELOG.md updated
- [x] Present new features in [N&N](https://cqse.atlassian.net/l/cp/KHSr81m1)
- [x] [TGA Tutorial](https://docs.teamscale.com/tutorial/setting-up-tga-java) updated
- [x] [TIA Tutorial](https://docs.teamscale.com/tutorial/tia-java/) updated

Please respect the vote of the [Teamscale bot](https://demo.teamscale.com) or flag irrelevant findings as tolerated or false positives. If you feel that the Teamscale config needs adjustment, please state so in a comment and discuss this with your reviewer.

