### PR TITLE
TS-36278 Fix same uniform path being extracted for multiple tests wit…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ We use [semantic versioning](http://semver.org/):
 # Next Release
 - [feature] _agent_: Added stable support for Java 21 and experimental support for Java 22
 - [fix] _agent_: Produce more helpful error results in case a service call to Teamscale fails while handling an HTTP call 
+- [fix] _teamscale-maven-plugin_: The same uniform paths were extracted for tests that have the same name in a Cucumber feature file 
 
 # 32.3.1
 - Re-release because of failing publishing process

--- a/impacted-test-engine/src/main/java/com/teamscale/test_impacted/test_descriptor/CucumberPickleDescriptorResolver.java
+++ b/impacted-test-engine/src/main/java/com/teamscale/test_impacted/test_descriptor/CucumberPickleDescriptorResolver.java
@@ -6,12 +6,15 @@ import org.junit.platform.engine.TestDescriptor;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.logging.Logger;
 
 /**
  * Test descriptor resolver for Cucumber. For details how we extract the uniform path, see comment in
- * {@link #getPickleId(TestDescriptor)}. The cluster id is the .feature file in which the tests are defined.
+ * {@link #getPickleName(TestDescriptor)}. The cluster id is the .feature file in which the tests are defined.
  */
 public class CucumberPickleDescriptorResolver implements ITestDescriptorResolver {
 	/** Name of the cucumber test engine as used in the unique id of the test descriptor */
@@ -29,14 +32,24 @@ public class CucumberPickleDescriptorResolver implements ITestDescriptorResolver
 					testDescriptor + ". This is probably a bug. Please report to CQSE");
 			return Optional.empty();
 		}
-		Optional<String> pickleName = getPickleId(testDescriptor);
+		Optional<String> pickleName = getPickleName(testDescriptor);
 		if (!pickleName.isPresent()) {
 			LOGGER.severe(() -> "Cannot resolve the pickle name for " +
 					testDescriptor + ". This is probably a bug. Please report to CQSE");
 			return Optional.empty();
 		}
+		String uniformPath = featurePath.get() + "/" + pickleName.get();
 
-		return Optional.of(featurePath.get() + "/" + pickleName.get());
+		// Add an index to the end of the name in case multiple tests have the same name in the same feature file
+		Optional<TestDescriptor> featureFileTestDescriptor = getFeatureFileTestDescriptor(testDescriptor);
+		if (featureFileTestDescriptor.isPresent()) {
+			List<? extends TestDescriptor> siblingTestsWithTheSameName = flatListOfAllTestDescriptorChildrenWithPickleName(
+					featureFileTestDescriptor.get(), pickleName.get());
+			int indexOfCurrentTest = siblingTestsWithTheSameName.indexOf(testDescriptor) + 1;
+			uniformPath += " #" + indexOfCurrentTest;
+		}
+
+		return Optional.of(uniformPath);
 	}
 
 	@Override
@@ -60,7 +73,7 @@ public class CucumberPickleDescriptorResolver implements ITestDescriptorResolver
 		return featureClasspath.map(featureClasspathString -> featureClasspathString.replaceAll("classpath:", ""));
 	}
 
-	private Optional<String> getPickleId(TestDescriptor testDescriptor) {
+	private Optional<String> getPickleName(TestDescriptor testDescriptor) {
 		// The PickleDescriptor test descriptor class is not public, so we can't import and use it to get access to the pickle attribute containing the name => reflection
 		// https://github.com/cucumber/cucumber-jvm/blob/main/cucumber-junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/NodeDescriptor.java#L90
 		// We want to use the name, though, because the unique id of the test descriptor can easily result in inconsistencies,
@@ -82,15 +95,8 @@ public class CucumberPickleDescriptorResolver implements ITestDescriptorResolver
 		// This means, everytime the line numbers change the test would not be recognised as the same in Teamscale anymore.
 		// So we use the pickle name (testDescriptor.pickle.getName()) to get the descriptive name "Add two numbers".
 		// This is not unique yet, as all the executions of the test (all examples) will have the same name then => may not be the case in Teamscale.
-		// To resolve this, we add the display name of the test descriptor at the end (testDescriptor.getDisplayName), which will be "Example #1.1", Example #1.2", etc.
-		// For normal Scenarios, this will result in the pickle name twice, which we accept here. E.g.
-		//
-		// Scenario: Add two numbers 0 & 0
-		//    Given I have a calculator
-		//    When I add 0 and 0
-		//    Then the result should be 0
-		//
-		// Results in "Add two numbers 0 & 0/Add two numbers 0 & 0"
+		// To resolve this, we add an index afterwards in getUniformPath()
+
 		Field pickleField = null;
 		try {
 			pickleField = testDescriptor.getClass().getDeclaredField("pickle");
@@ -109,10 +115,41 @@ public class CucumberPickleDescriptorResolver implements ITestDescriptorResolver
 			Method getNameMethod = pickle.getClass().getDeclaredMethod("getName");
 			getNameMethod.setAccessible(true);
 			String name = getNameMethod.invoke(pickle).toString();
-			String id = name + "/" + testDescriptor.getDisplayName();
-			return Optional.of(id);
+			return Optional.of(name);
 		} catch (NoSuchFieldException | InvocationTargetException | IllegalAccessException | NoSuchMethodException e) {
 			return Optional.empty();
 		}
+	}
+
+	private Optional<TestDescriptor> getFeatureFileTestDescriptor(TestDescriptor testDescriptor) {
+		if (!isFeatureFileTestDescriptor(testDescriptor)) {
+			if (!testDescriptor.getParent().isPresent()) {
+				return Optional.empty();
+			}
+			return getFeatureFileTestDescriptor(testDescriptor.getParent().get());
+		}
+		return Optional.of(testDescriptor);
+	}
+
+	private boolean isFeatureFileTestDescriptor(TestDescriptor cucumberTestDescriptor) {
+		return cucumberTestDescriptor.getUniqueId().getLastSegment().getType().equals(FEATURE_SEGMENT_TYPE);
+	}
+
+	private List<TestDescriptor> flatListOfAllTestDescriptorChildrenWithPickleName(TestDescriptor testDescriptor,
+																				   String pickleName) {
+		if (testDescriptor.getChildren().isEmpty()) {
+			Optional<String> pickleId = getPickleName(testDescriptor);
+			if (pickleId.isPresent() && pickleName.equals(pickleId.get())) {
+				return Collections.singletonList(testDescriptor);
+			}
+			return Collections.emptyList();
+		}
+		List<TestDescriptor> flattenedChildDescriptors = new ArrayList<>();
+		for (TestDescriptor childDescriptor : testDescriptor.getChildren()) {
+			flattenedChildDescriptors.addAll(
+					flatListOfAllTestDescriptorChildrenWithPickleName(childDescriptor, pickleName));
+		}
+		return flattenedChildDescriptors;
+
 	}
 }

--- a/system-tests/cucumber-maven-tia/maven-project/src/test/resources/hellocucumber/calculator.feature
+++ b/system-tests/cucumber-maven-tia/maven-project/src/test/resources/hellocucumber/calculator.feature
@@ -3,9 +3,14 @@ Feature: Calculator
   I want to use a calculator to add numbers
   So that I don't need to add myself
 
-  Scenario: Add two numbers 0 & 0
+  Scenario: Add two numbers
     Given I have a calculator
     When I add 0 and 0
+    Then the result should be 0
+
+  Scenario: Add two numbers
+    Given I have a calculator
+    When I add 1 and -1
     Then the result should be 0
 
   Scenario Outline: Add two numbers

--- a/system-tests/cucumber-maven-tia/src/test/java/com/teamscale/tia/TiaMavenCucumberSystemTest.java
+++ b/system-tests/cucumber-maven-tia/src/test/java/com/teamscale/tia/TiaMavenCucumberSystemTest.java
@@ -29,9 +29,11 @@ public class TiaMavenCucumberSystemTest {
 		if (teamscaleMockServer == null) {
 			teamscaleMockServer = new TeamscaleMockServer(FAKE_TEAMSCALE_PORT).acceptingReportUploads()
 					.withImpactedTests(
-							"hellocucumber/RunCucumberTest/hellocucumber/calculator.feature/Add two numbers 0 & 0/Add two numbers 0 & 0",
-							"hellocucumber/RunCucumberTest/hellocucumber/calculator.feature/Add two numbers/Example #1.1",
-							"hellocucumber/RunCucumberTest/hellocucumber/calculator.feature/Add two numbers/Example #1.2");
+							"hellocucumber/RunCucumberTest/hellocucumber/calculator.feature/Add two numbers #1",
+							"hellocucumber/RunCucumberTest/hellocucumber/calculator.feature/Add two numbers #2",
+							"hellocucumber/RunCucumberTest/hellocucumber/calculator.feature/Add two numbers #3",
+							"hellocucumber/RunCucumberTest/hellocucumber/calculator.feature/Add two numbers #4",
+							"hellocucumber/RunCucumberTest/hellocucumber/calculator.feature/Subtract two numbers 99 & 99 #1");
 		}
 		teamscaleMockServer.uploadedReports.clear();
 	}
@@ -50,24 +52,26 @@ public class TiaMavenCucumberSystemTest {
 		assertThat(teamscaleMockServer.uploadedReports).hasSize(1);
 
 		TestwiseCoverageReport unitTestReport = teamscaleMockServer.parseUploadedTestwiseCoverageReport(0);
-		assertThat(unitTestReport.tests).hasSize(3);
+		assertThat(unitTestReport.tests).hasSize(5);
 		assertThat(unitTestReport.partial).isTrue();
 		assertAll(() -> {
 			assertThat(unitTestReport.tests).extracting(test -> test.uniformPath)
 					.containsExactlyInAnyOrder(
-							"hellocucumber/RunCucumberTest/hellocucumber/calculator.feature/Add two numbers 0 & 0/Add two numbers 0 & 0",
-							"hellocucumber/RunCucumberTest/hellocucumber/calculator.feature/Add two numbers/Example #1.1",
-							"hellocucumber/RunCucumberTest/hellocucumber/calculator.feature/Add two numbers/Example #1.2"
-					);
+							"hellocucumber/RunCucumberTest/hellocucumber/calculator.feature/Add two numbers #1",
+							"hellocucumber/RunCucumberTest/hellocucumber/calculator.feature/Add two numbers #2",
+							"hellocucumber/RunCucumberTest/hellocucumber/calculator.feature/Add two numbers #3",
+							"hellocucumber/RunCucumberTest/hellocucumber/calculator.feature/Add two numbers #4",
+							"hellocucumber/RunCucumberTest/hellocucumber/calculator.feature/Subtract two numbers 99 & 99 #1");
 			assertThat(unitTestReport.tests).extracting(test -> test.result)
 					.containsExactlyInAnyOrder(ETestExecutionResult.PASSED, ETestExecutionResult.PASSED,
-							ETestExecutionResult.PASSED);
+							ETestExecutionResult.PASSED, ETestExecutionResult.PASSED, ETestExecutionResult.PASSED);
 			assertThat(unitTestReport.tests).extracting(SystemTestUtils::getCoverageString)
 					.containsExactly(
 							"Calculator.java:3,5;StepDefinitions.java:12,24-25,29-30,39-40",
 							"Calculator.java:3,5;StepDefinitions.java:12,24-25,29-30,39-40",
-							"Calculator.java:3,5;StepDefinitions.java:12,24-25,29-30,39-40"
-					);
+							"Calculator.java:3,5;StepDefinitions.java:12,24-25,29-30,39-40",
+							"Calculator.java:3,5;StepDefinitions.java:12,24-25,29-30,39-40",
+							"Calculator.java:3,9;StepDefinitions.java:12,24-25,34-35,39-40");
 		});
 	}
 


### PR DESCRIPTION
…h the same name in a cucumber feature file

Addresses issue [TS-36278](https://cqse.atlassian.net/browse/TS-36278)

- [x] Changes are tested adequately => tbd @DreierF 
- [x] Agent's README.md updated in case of user-visible changes
- [x] CHANGELOG.md updated
- [x] Present new features in [N&N](https://cqse.atlassian.net/l/cp/KHSr81m1)
- [x] [TGA Tutorial](https://docs.teamscale.com/tutorial/setting-up-tga-java) updated
- [x] [TIA Tutorial](https://docs.teamscale.com/tutorial/tia-java/) updated

Please respect the vote of the [Teamscale bot](https://demo.teamscale.com) or flag irrelevant findings as tolerated or false positives. If you feel that the Teamscale config needs adjustment, please state so in a comment and discuss this with your reviewer.

