### PR TITLE
don't warn about proxy port when no port is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ We use [semantic versioning](http://semver.org/):
 
 # Next Release
 - [feature] Docker: agent copies itself to `/transfer` if this is mounted into the container
+- [fix] Disable warning about proxy port not being correct when no proxy port was set at all
 
 # 33.1.2
 - [fix] _teamscale-maven-plugin_: Revision and end commit could not be set via command line (user property)

--- a/teamscale-client/src/main/java/com/teamscale/client/ProxySystemProperties.java
+++ b/teamscale-client/src/main/java/com/teamscale/client/ProxySystemProperties.java
@@ -70,7 +70,8 @@ public class ProxySystemProperties {
 	}
 
 	/**
-	 * Read the http(s).proxyPort system variable
+	 * Read the http(s).proxyPort system variable.
+	 * Returns -1 if no or an invalid port was set.
 	 */
 	public int getProxyPort() {
 		return parsePort(System.getProperty(getProxyPortSystemPropertyName()));
@@ -100,6 +101,14 @@ public class ProxySystemProperties {
 	 */
 	public void setProxyPort(String proxyPort) {
 		System.setProperty(getProxyPortSystemPropertyName(), proxyPort);
+	}
+
+	/**
+	 * Removes the http(s).proxyPort system variable.
+	 * For testing.
+	 */
+	/*package*/ void removeProxyPort() {
+		System.clearProperty(getProxyPortSystemPropertyName());
 	}
 
 	@NotNull
@@ -146,7 +155,12 @@ public class ProxySystemProperties {
 		return protocol + PROXY_PASSWORD_SYSTEM_PROPERTY;
 	}
 
+	/** Parses the given port string. Returns -1 if the string is null or not a valid number. */
 	private int parsePort(String portString) {
+		if (portString == null) {
+			return -1;
+		}
+
 		try {
 			return Integer.parseInt(portString);
 		} catch (NumberFormatException e) {

--- a/teamscale-client/src/test/java/com/teamscale/client/ProxySystemPropertiesTest.java
+++ b/teamscale-client/src/test/java/com/teamscale/client/ProxySystemPropertiesTest.java
@@ -1,0 +1,28 @@
+package com.teamscale.client;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+
+class ProxySystemPropertiesTest {
+
+	private static ProxySystemProperties properties = new ProxySystemProperties(ProxySystemProperties.Protocol.HTTP);
+
+	@AfterAll
+	static void teardown() {
+		properties.removeProxyPort();
+	}
+
+	@Test
+	void testPortParsing() {
+		properties.setProxyPort(9876);
+		Assertions.assertThat(properties.getProxyPort()).isEqualTo(9876);
+		properties.setProxyPort("");
+		Assertions.assertThat(properties.getProxyPort()).isEqualTo(-1);
+		properties.setProxyPort("nonsense");
+		Assertions.assertThat(properties.getProxyPort()).isEqualTo(-1);
+		properties.removeProxyPort();
+		Assertions.assertThat(properties.getProxyPort()).isEqualTo(-1);
+	}
+
+}


### PR DESCRIPTION
Addresses issue [TS-38166](https://cqse.atlassian.net/browse/TS-38166)

- [x] Changes are tested adequately
- [x] Agent's README.md updated in case of user-visible changes
- [x] CHANGELOG.md updated
- [x] Present new features in [N&N](https://cqse.atlassian.net/l/cp/KHSr81m1)
- [x] [TGA Tutorial](https://docs.teamscale.com/tutorial/setting-up-tga-java) updated
- [x] [TIA Tutorial](https://docs.teamscale.com/tutorial/tia-java/) updated

Please respect the vote of the [Teamscale bot](https://demo.teamscale.com) or flag irrelevant findings as tolerated or false positives. If you feel that the Teamscale config needs adjustment, please state so in a comment and discuss this with your reviewer.

