### PR TITLE
TS-38948 TIA Maven Plugin: Upload to Teamscale goes sha1 "branch" instead of an actual branch when in detached head state (e.g. in GitLab pipelines)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ We use [semantic versioning](http://semver.org/):
 # Next Release
 - [feature] _agent_: Support overwriting the git commit inside `git.properties` files with `teamscale.commit.branch` and `teamscale.commit.time` (see [docs](agent/README.md#overwriting-the-git-commit-inside-gitproperties-files-with-teamscalecommitbranch-and-teamscalecommittime))
 - [fix] _agent_: New default date format of the [git-commit-id-maven-plugin](https://github.com/git-commit-id/git-commit-id-maven-plugin) could not be parsed (see [GitHub Issue](https://github.com/cqse/teamscale-jacoco-agent/issues/464))
+- [fix] _teamscale-maven-plugin_: Testwise coverage upload did not work in detached head state (e.g. in GitLab pipelines)
 
 # 33.2.0
 - [feature] _agent_: Add support for git.properties in Spring Boot 3.2

--- a/teamscale-maven-plugin/src/main/java/com/teamscale/maven/TeamscaleMojoBase.java
+++ b/teamscale-maven-plugin/src/main/java/com/teamscale/maven/TeamscaleMojoBase.java
@@ -103,6 +103,26 @@ public abstract class TeamscaleMojoBase extends AbstractMojo {
 	}
 
 	/**
+	 * Sets the <code>resolvedRevision</code>, if not provided, via the GitCommit class
+	 *
+	 * @see GitCommit
+	 */
+	protected void resolveRevision() throws MojoFailureException {
+		if (StringUtils.isNotBlank(revision)) {
+			resolvedRevision = revision;
+		} else {
+			Path basedir = session.getCurrentProject().getBasedir().toPath();
+			try {
+				GitCommit commit = GitCommit.getGitHeadCommitDescriptor(basedir);
+				resolvedRevision = commit.sha1;
+			} catch (IOException e) {
+				throw new MojoFailureException("There is no <revision> configured in the pom.xml" +
+						" and it was not possible to determine the current revision in " + basedir + " from Git", e);
+			}
+		}
+	}
+
+	/**
 	 * Retrieves the configuration of a goal execution for the given plugin
 	 * @param pluginArtifact The id of the plugin
 	 * @param pluginGoal The name of the goal

--- a/teamscale-maven-plugin/src/main/java/com/teamscale/maven/tia/TiaMojoBase.java
+++ b/teamscale-maven-plugin/src/main/java/com/teamscale/maven/tia/TiaMojoBase.java
@@ -2,6 +2,7 @@ package com.teamscale.maven.tia;
 
 import com.teamscale.maven.TeamscaleMojoBase;
 import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.util.Strings;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.model.Plugin;
@@ -167,6 +168,7 @@ public abstract class TiaMojoBase extends TeamscaleMojoBase {
 		createTargetDirectory();
 
 		resolveEndCommit();
+		resolveRevision();
 
 		setTiaProperty("reportDirectory", targetDirectory.toString());
 		setTiaProperty("server.url", teamscaleUrl);
@@ -362,7 +364,6 @@ public abstract class TiaMojoBase extends TeamscaleMojoBase {
 				"\nteamscale-project=" + projectId +
 				"\nteamscale-user=" + username +
 				"\nteamscale-access-token=" + accessToken +
-				"\nteamscale-commit=" + resolvedCommit +
 				"\nteamscale-partition=" + getPartition() +
 				"\nhttp-server-port=" + agentPort +
 				"\nlogging-config=" + loggingConfigPath +
@@ -372,6 +373,14 @@ public abstract class TiaMojoBase extends TeamscaleMojoBase {
 		}
 		if (ArrayUtils.isNotEmpty(excludes)) {
 			config += "\nexcludes=" + String.join(";", excludes);
+		}
+
+		// endCommit is only set via the config option in the pom. If the user sets it, prefer it over the revision.
+		// If not, prefer the revision
+		if (StringUtils.isEmpty(endCommit) && StringUtils.isNotEmpty(resolvedRevision)) {
+			config += "\nteamscale-revision=" + resolvedRevision;
+		} else {
+			config += "\nteamscale-commit=" + resolvedCommit;
 		}
 		return config;
 	}

--- a/teamscale-maven-plugin/src/main/java/com/teamscale/maven/upload/CoverageUploadMojo.java
+++ b/teamscale-maven-plugin/src/main/java/com/teamscale/maven/upload/CoverageUploadMojo.java
@@ -1,9 +1,7 @@
 package com.teamscale.maven.upload;
 
 import com.google.common.base.Strings;
-import com.teamscale.maven.GitCommit;
 import com.teamscale.maven.TeamscaleMojoBase;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -267,20 +265,5 @@ public class CoverageUploadMojo extends TeamscaleMojoBase {
 
 	private Xpp3Dom getJacocoGoalExecutionConfiguration(MavenProject project, String pluginGoal) {
 		return super.getExecutionConfigurationDom(project, JACOCO_PLUGIN_NAME, pluginGoal);
-	}
-
-	private void resolveRevision() throws MojoFailureException {
-		if (StringUtils.isNotBlank(revision)) {
-			resolvedRevision = revision;
-		} else {
-			Path basedir = session.getCurrentProject().getBasedir().toPath();
-			try {
-				GitCommit commit = GitCommit.getGitHeadCommitDescriptor(basedir);
-				resolvedRevision = commit.sha1;
-			} catch (IOException e) {
-				throw new MojoFailureException("There is no <revision> configured in the pom.xml" +
-						" and it was not possible to determine the current revision in " + basedir + " from Git", e);
-			}
-		}
 	}
 }


### PR DESCRIPTION
Addresses issue [TS-38967](https://cqse.atlassian.net/browse/TS-38967)

- [x] Changes are tested adequately
- [x] Agent's README.md updated in case of user-visible changes
- [x] CHANGELOG.md updated
- [ ] Present new features in [N&N](https://cqse.atlassian.net/l/cp/KHSr81m1)
- [x] [TGA Tutorial](https://docs.teamscale.com/tutorial/setting-up-tga-java) updated
- [x] [TIA Tutorial](https://docs.teamscale.com/tutorial/tia-java/) updated

Please respect the vote of the [Teamscale bot](https://demo.teamscale.com) or flag irrelevant findings as tolerated or false positives. If you feel that the Teamscale config needs adjustment, please state so in a comment and discuss this with your reviewer.

