### PR TITLE
TS-46135: Fix coverage aggregation skipped when tests fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ We use [semantic versioning](http://semver.org/):
 
 # Next version
 - [feature] _agent_: Renamed the docker image to `cqse/teamscale-java-profiler` and added support for the `linux/arm64` platform
+- [fix] _teamscale-gradle-plugin_: Coverage aggregation report and upload were skipped when tests failed with `--continue`
 
 # 36.4.1
 - [fix] _agent_: Fixed `IllegalStateException: Can't add different class with same name` when application servers like JBoss perform a reload without full restart or when duplicate class files exist across multiple archives

--- a/teamscale-gradle-plugin/src/main/kotlin/com/teamscale/aggregation/compact/CompactCoverageAggregationPlugin.kt
+++ b/teamscale-gradle-plugin/src/main/kotlin/com/teamscale/aggregation/compact/CompactCoverageAggregationPlugin.kt
@@ -52,9 +52,7 @@ abstract class CompactCoverageAggregationPlugin : Plugin<Project> {
 					attributes.artifactType(ArtifactTypeDefinition.BINARY_DATA_TYPE)
 				}.files
 				this.executionData.from(executionData)
-				dependsOn(executionData.buildDependencies)
 				this.classDirectories.from(classDirectories)
-				dependsOn(classDirectories.buildDependencies)
 			}
 		}
 

--- a/teamscale-gradle-plugin/src/test/kotlin/com/teamscale/CompactCoverageAggregationTest.kt
+++ b/teamscale-gradle-plugin/src/test/kotlin/com/teamscale/CompactCoverageAggregationTest.kt
@@ -1,0 +1,133 @@
+package com.teamscale
+
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests the compact coverage aggregation plugin across multiple subprojects,
+ * specifically that the aggregation report is still generated when tests fail with --continue.
+ */
+class CompactCoverageAggregationTest : TeamscalePluginTestBase() {
+
+	@BeforeEach
+	fun init() {
+		setupSettings()
+		setupRootBuildFile()
+		setupSubprojectMod1()
+	}
+
+	private fun setupSettings() {
+		rootProject.settingsFile.writeText(
+			"""
+dependencyResolutionManagement {
+	repositories {
+		mavenLocal()
+		mavenCentral()
+	}
+}
+
+include 'mod1'
+			""".trimIndent()
+		)
+	}
+
+	private fun setupRootBuildFile() {
+		rootProject.buildFile.writeText(
+			"""
+import com.teamscale.aggregation.TestSuiteCompatibilityUtil
+import com.teamscale.aggregation.compact.AggregateCompactCoverageReport
+
+plugins {
+	id 'java'
+	id 'com.teamscale'
+	id 'com.teamscale.aggregation'
+}
+
+teamscale {
+	commit {
+		revision = "abcd1337"
+	}
+	repository = "myRepoId"
+}
+
+dependencies {
+	reportAggregation(subprojects)
+}
+
+reporting {
+	reports {
+		unitTestAggregateCompactCoverageReport(AggregateCompactCoverageReport) { testSuiteName = 'unitTest' }
+	}
+}
+
+subprojects {
+	apply plugin: 'com.teamscale'
+
+	tasks.register('runUnitTests', Test) {
+		useJUnitPlatform()
+		testClassesDirs = sourceSets.test.output.classesDirs
+		classpath = sourceSets.test.runtimeClasspath
+	}
+	TestSuiteCompatibilityUtil.exposeTestForAggregation(tasks.named('runUnitTests'), 'unitTest')
+}
+			""".trimIndent()
+		)
+	}
+
+	private fun setupSubprojectMod1() {
+		java.io.File(rootProject.dir("mod1"), "build.gradle").writeText(
+			"""
+plugins {
+	id 'java'
+}
+
+dependencies {
+	testImplementation(platform("org.junit:junit-bom:5.12.0"))
+	testImplementation("org.junit.jupiter:junit-jupiter")
+	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+			""".trimIndent()
+		)
+
+		rootProject.file("mod1/src/main/java/com/example/Lib.java").writeText(
+			"""
+package com.example;
+
+public class Lib {
+	public static int add(int a, int b) {
+		return a + b;
+	}
+}
+			""".trimIndent()
+		)
+
+		rootProject.file("mod1/src/test/java/com/example/LibTest.java").writeText(
+			"""
+package com.example;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class LibTest {
+	@Test
+	void failingTest() {
+		assertEquals(3, Lib.add(1, 2));
+		throw new RuntimeException("intentional failure");
+	}
+}
+			""".trimIndent()
+		)
+	}
+
+	@Test
+	fun `compact coverage aggregation runs despite test failure with --continue`() {
+		val build = runExpectingError("--continue", "clean", "unitTestAggregateCompactCoverageReport")
+
+		assertThat(build.task(":mod1:runUnitTests")?.outcome)
+			.isEqualTo(TaskOutcome.FAILED)
+		assertThat(build.task(":unitTestAggregateCompactCoverageReport")?.outcome)
+			.isEqualTo(TaskOutcome.SUCCESS)
+	}
+}


### PR DESCRIPTION
Remove explicit dependsOn(buildDependencies) calls from CompactCoverageAggregationPlugin. The implicit dependency through @InputFiles on executionData/classDirectories is sufficient for task ordering and, unlike explicit dependsOn, does not block the aggregation task when a test task fails with --continue.

This matches the pattern used by Gradle's official jacoco-report-aggregation plugin.

Addresses issue [TS-46135](https://cqse.atlassian.net/browse/TS-46135)

- [x] Changes are tested adequately
- [ ] Teamscale documentation updated in case of user-visible changes
- [x] CHANGELOG.md updated
- [ ] Present new features in [N&N](https://cqse.atlassian.net/l/cp/KHSr81m1)
- [ ] [TGA Tutorial](https://docs.teamscale.com/tutorial/setting-up-tga-java) updated
- [ ] [TIA Tutorial](https://docs.teamscale.com/tutorial/tia-java/) updated

Please respect the vote of the [Teamscale bot](https://demo.teamscale.com) or flag irrelevant findings as tolerated or false positives. If you feel that the Teamscale config needs adjustment, please state so in a comment and discuss this with your reviewer.

